### PR TITLE
Control thinking and sampling per Claude model

### DIFF
--- a/packages/anthropic-adapter/src/Chat/AnthropicChatAdapter.php
+++ b/packages/anthropic-adapter/src/Chat/AnthropicChatAdapter.php
@@ -71,6 +71,7 @@ final readonly class AnthropicChatAdapter implements AIChatAdapterInterface, Sup
         private ClientInterface $client,
         private string $model,
         private int $maxTokens = 1024,
+        private ?ThinkingModeEnum $thinking = null,
     ) {
     }
 
@@ -88,8 +89,17 @@ final readonly class AnthropicChatAdapter implements AIChatAdapterInterface, Sup
         }
 
         if ($temperature = $request->getOption('temperature')) {
-            /** @var float $temperature */
-            $parameters['temperature'] = $temperature;
+            if (ModelCapabilities::supportsSampling($this->model)) {
+                /** @var float $temperature */
+                $parameters['temperature'] = $temperature;
+            } else {
+                @\trigger_error(\sprintf('Temperature option is not supported by "%s".', $this->model), \E_USER_WARNING);
+            }
+        }
+
+        $thinking = $this->resolveThinking();
+        if ($thinking instanceof ThinkingModeEnum) {
+            $parameters['thinking'] = ['type' => $thinking->value];
         }
 
         if ($request->hasTools()) {
@@ -194,6 +204,35 @@ final readonly class AnthropicChatAdapter implements AIChatAdapterInterface, Sup
         }
 
         return $this->create($request, $parameters);
+    }
+
+    /**
+     * Anthropic thinks adaptively on newer models unless told otherwise, which costs output tokens
+     * and latency. Keep the adapter's long standing behaviour and opt out unless configured
+     * otherwise.
+     */
+    private function resolveThinking(): ?ThinkingModeEnum
+    {
+        if (!$this->thinking instanceof ThinkingModeEnum) {
+            return ModelCapabilities::thinksByDefault($this->model)
+                && ModelCapabilities::supportsDisabledThinking($this->model)
+                    ? ThinkingModeEnum::DISABLED
+                    : null;
+        }
+
+        if (!ModelCapabilities::supportsThinking($this->model)) {
+            @\trigger_error(\sprintf('Thinking is not supported by "%s".', $this->model), \E_USER_WARNING);
+
+            return null;
+        }
+
+        if (ThinkingModeEnum::DISABLED === $this->thinking && !ModelCapabilities::supportsDisabledThinking($this->model)) {
+            @\trigger_error(\sprintf('Thinking cannot be disabled for "%s".', $this->model), \E_USER_WARNING);
+
+            return null;
+        }
+
+        return $this->thinking;
     }
 
     /**

--- a/packages/anthropic-adapter/src/Chat/AnthropicChatAdapterFactory.php
+++ b/packages/anthropic-adapter/src/Chat/AnthropicChatAdapterFactory.php
@@ -22,6 +22,7 @@ final readonly class AnthropicChatAdapterFactory implements AIChatAdapterFactory
     public function __construct(
         private ClientInterface $client,
         private int $maxTokens = 1024,
+        private ?ThinkingModeEnum $thinking = null,
     ) {
     }
 
@@ -31,6 +32,7 @@ final readonly class AnthropicChatAdapterFactory implements AIChatAdapterFactory
             $this->client,
             $options['model'],
             $this->maxTokens,
+            $this->thinking,
         );
     }
 }

--- a/packages/anthropic-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/anthropic-adapter/src/Chat/ModelCapabilities.php
@@ -29,6 +29,7 @@ final class ModelCapabilities
     private const SAMPLING_REMOVED = [
         'claude-fable-5',
         'claude-mythos-5',
+        'claude-mythos-preview',
         'claude-opus-5',
         'claude-sonnet-5',
         'claude-opus-4-8',
@@ -44,6 +45,7 @@ final class ModelCapabilities
     private const THINKING_SUPPORTED = [
         'claude-fable-5',
         'claude-mythos-5',
+        'claude-mythos-preview',
         'claude-opus-5',
         'claude-sonnet-5',
         'claude-opus-4-8',
@@ -61,6 +63,7 @@ final class ModelCapabilities
     private const THINKING_ON_BY_DEFAULT = [
         'claude-fable-5',
         'claude-mythos-5',
+        'claude-mythos-preview',
         'claude-opus-5',
         'claude-sonnet-5',
     ];
@@ -73,6 +76,7 @@ final class ModelCapabilities
     private const THINKING_ALWAYS_ON = [
         'claude-fable-5',
         'claude-mythos-5',
+        'claude-mythos-preview',
     ];
 
     public static function supportsSampling(string $model): bool

--- a/packages/anthropic-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/anthropic-adapter/src/Chat/ModelCapabilities.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\AnthropicAdapter\Chat;
+
+/**
+ * Request-surface differences between Claude generations. Anthropic answers with a 400 instead of
+ * ignoring an unsupported field, so the adapter has to know which model it is talking to.
+ *
+ * @see https://platform.claude.com/docs/en/docs/build-with-claude/extended-thinking
+ */
+final class ModelCapabilities
+{
+    /**
+     * Sampling (temperature, top_p, top_k) was removed with Opus 4.7 and is rejected since.
+     *
+     * @var list<string>
+     */
+    private const SAMPLING_REMOVED = [
+        'claude-fable-5',
+        'claude-mythos-5',
+        'claude-opus-5',
+        'claude-sonnet-5',
+        'claude-opus-4-8',
+        'claude-opus-4-7',
+    ];
+
+    /**
+     * Models accepting the `thinking` parameter. Older models expect `budget_tokens`, which this
+     * adapter does not send.
+     *
+     * @var list<string>
+     */
+    private const THINKING_SUPPORTED = [
+        'claude-fable-5',
+        'claude-mythos-5',
+        'claude-opus-5',
+        'claude-sonnet-5',
+        'claude-opus-4-8',
+        'claude-opus-4-7',
+        'claude-opus-4-6',
+        'claude-sonnet-4-6',
+    ];
+
+    /**
+     * Models thinking adaptively when `thinking` is omitted. Everywhere else omitting it means no
+     * thinking, so `disabled` only has to be sent for these.
+     *
+     * @var list<string>
+     */
+    private const THINKING_ON_BY_DEFAULT = [
+        'claude-fable-5',
+        'claude-mythos-5',
+        'claude-opus-5',
+        'claude-sonnet-5',
+    ];
+
+    /**
+     * Fable and Mythos always think; `disabled` is rejected with a 400.
+     *
+     * @var list<string>
+     */
+    private const THINKING_ALWAYS_ON = [
+        'claude-fable-5',
+        'claude-mythos-5',
+    ];
+
+    public static function supportsSampling(string $model): bool
+    {
+        return !self::matches($model, self::SAMPLING_REMOVED);
+    }
+
+    public static function supportsThinking(string $model): bool
+    {
+        return self::matches($model, self::THINKING_SUPPORTED);
+    }
+
+    public static function thinksByDefault(string $model): bool
+    {
+        return self::matches($model, self::THINKING_ON_BY_DEFAULT);
+    }
+
+    public static function supportsDisabledThinking(string $model): bool
+    {
+        return self::supportsThinking($model) && !self::matches($model, self::THINKING_ALWAYS_ON);
+    }
+
+    /**
+     * @param list<string> $models
+     */
+    private static function matches(string $model, array $models): bool
+    {
+        foreach ($models as $candidate) {
+            // Dated snapshots such as "claude-haiku-4-5-20251001" share the base model's surface.
+            if ($model === $candidate || \str_starts_with($model, $candidate . '-')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/anthropic-adapter/src/Chat/ThinkingModeEnum.php
+++ b/packages/anthropic-adapter/src/Chat/ThinkingModeEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\AnthropicAdapter\Chat;
+
+enum ThinkingModeEnum: string
+{
+    case ADAPTIVE = 'adaptive';
+    case DISABLED = 'disabled';
+}

--- a/packages/anthropic-adapter/tests/Unit/Chat/AnthropicChatAdapterTest.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/AnthropicChatAdapterTest.php
@@ -18,6 +18,7 @@ use ModelflowAi\Anthropic\ClientInterface;
 use ModelflowAi\Anthropic\DataFixtures;
 use ModelflowAi\Anthropic\Model;
 use ModelflowAi\AnthropicAdapter\Chat\AnthropicChatAdapter;
+use ModelflowAi\AnthropicAdapter\Chat\ThinkingModeEnum;
 use ModelflowAi\ApiClient\Responses\MetaInformation;
 use ModelflowAi\ApiClient\Transport\Payload;
 use ModelflowAi\ApiClient\Transport\Response\ObjectResponse;
@@ -802,5 +803,97 @@ final class AnthropicChatAdapterTest extends TestCase
         $adapter = new AnthropicChatAdapter($client->reveal(), Model::CLAUDE_3_SONNET->value);
 
         $this->assertFalse($adapter->supportsResponseFormat($unsupportedFormat->reveal()));
+    }
+
+    public function testHandleRequestDisablesThinkingForThinkingByDefaultModel(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-sonnet-5', 100);
+
+        $adapter->handleRequest($this->createRequest());
+
+        $this->assertSame(['type' => 'disabled'], $transport->parameters['thinking'] ?? null);
+    }
+
+    public function testHandleRequestOmitsThinkingForModelWithoutThinking(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), Model::CLAUDE_3_HAIKU->value, 100);
+
+        $adapter->handleRequest($this->createRequest());
+
+        $this->assertArrayNotHasKey('thinking', $transport->parameters);
+    }
+
+    public function testHandleRequestOmitsThinkingForModelWithThinkingOffByDefault(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-opus-4-8', 100);
+
+        $adapter->handleRequest($this->createRequest());
+
+        $this->assertArrayNotHasKey('thinking', $transport->parameters);
+    }
+
+    public function testHandleRequestSendsConfiguredThinking(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-opus-4-8', 100, ThinkingModeEnum::ADAPTIVE);
+
+        $adapter->handleRequest($this->createRequest());
+
+        $this->assertSame(['type' => 'adaptive'], $transport->parameters['thinking'] ?? null);
+    }
+
+    public function testHandleRequestIgnoresThinkingForModelWithoutSupport(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), Model::CLAUDE_3_HAIKU->value, 100, ThinkingModeEnum::ADAPTIVE);
+
+        @$adapter->handleRequest($this->createRequest());
+
+        $this->assertArrayNotHasKey('thinking', $transport->parameters);
+    }
+
+    public function testHandleRequestIgnoresDisabledThinkingForAlwaysThinkingModel(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-fable-5', 100, ThinkingModeEnum::DISABLED);
+
+        @$adapter->handleRequest($this->createRequest());
+
+        $this->assertArrayNotHasKey('thinking', $transport->parameters);
+    }
+
+    public function testHandleRequestOmitsTemperatureForModelWithoutSampling(): void
+    {
+        $transport = $this->createCapturingTransport();
+        $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-opus-4-8', 100);
+
+        @$adapter->handleRequest($this->createRequest(['temperature' => 0.5]));
+
+        $this->assertArrayNotHasKey('temperature', $transport->parameters);
+    }
+
+    /**
+     * @param array{seed?: int, temperature?: float} $options
+     */
+    private function createRequest(array $options = []): AIChatRequest
+    {
+        return new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'Hello world!'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            $options,
+            static fn () => null,
+        );
+    }
+
+    private function createCapturingTransport(): CapturingTransport
+    {
+        return new CapturingTransport();
     }
 }

--- a/packages/anthropic-adapter/tests/Unit/Chat/AnthropicChatAdapterTest.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/AnthropicChatAdapterTest.php
@@ -850,8 +850,9 @@ final class AnthropicChatAdapterTest extends TestCase
         $transport = $this->createCapturingTransport();
         $adapter = new AnthropicChatAdapter(new Client($transport), Model::CLAUDE_3_HAIKU->value, 100, ThinkingModeEnum::ADAPTIVE);
 
-        @$adapter->handleRequest($this->createRequest());
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
 
+        $this->assertSame(['Thinking is not supported by "claude-3-haiku-20240307".'], $warnings);
         $this->assertArrayNotHasKey('thinking', $transport->parameters);
     }
 
@@ -860,8 +861,9 @@ final class AnthropicChatAdapterTest extends TestCase
         $transport = $this->createCapturingTransport();
         $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-fable-5', 100, ThinkingModeEnum::DISABLED);
 
-        @$adapter->handleRequest($this->createRequest());
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
 
+        $this->assertSame(['Thinking cannot be disabled for "claude-fable-5".'], $warnings);
         $this->assertArrayNotHasKey('thinking', $transport->parameters);
     }
 
@@ -870,8 +872,9 @@ final class AnthropicChatAdapterTest extends TestCase
         $transport = $this->createCapturingTransport();
         $adapter = new AnthropicChatAdapter(new Client($transport), 'claude-opus-4-8', 100);
 
-        @$adapter->handleRequest($this->createRequest(['temperature' => 0.5]));
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest(['temperature' => 0.5])));
 
+        $this->assertSame(['Temperature option is not supported by "claude-opus-4-8".'], $warnings);
         $this->assertArrayNotHasKey('temperature', $transport->parameters);
     }
 
@@ -895,5 +898,32 @@ final class AnthropicChatAdapterTest extends TestCase
     private function createCapturingTransport(): CapturingTransport
     {
         return new CapturingTransport();
+    }
+
+    /**
+     * The adapter suppresses its warnings with @, which PHPUnit honours, so they have to be read
+     * from an error handler instead.
+     *
+     * @return list<string>
+     */
+    private function captureWarnings(callable $callback): array
+    {
+        $warnings = [];
+
+        \set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+            if (\E_USER_WARNING === $severity) {
+                $warnings[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            $callback();
+        } finally {
+            \restore_error_handler();
+        }
+
+        return $warnings;
     }
 }

--- a/packages/anthropic-adapter/tests/Unit/Chat/CapturingTransport.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/CapturingTransport.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\AnthropicAdapter\Tests\Unit\Chat;
+
+use ModelflowAi\Anthropic\DataFixtures;
+use ModelflowAi\ApiClient\Responses\MetaInformation;
+use ModelflowAi\ApiClient\Transport\Payload;
+use ModelflowAi\ApiClient\Transport\Response\ObjectResponse;
+use ModelflowAi\ApiClient\Transport\Response\TextResponse;
+use ModelflowAi\ApiClient\Transport\TransportInterface;
+
+/**
+ * Records the sent parameters so a test can assert that a field is absent, which the partial
+ * payload matching of the mock transport cannot express.
+ */
+final class CapturingTransport implements TransportInterface
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public array $parameters = [];
+
+    public function requestObject(Payload $payload): ObjectResponse
+    {
+        $this->parameters = $payload->parameters;
+
+        return new ObjectResponse(DataFixtures::MESSAGES_CREATE_RESPONSE, MetaInformation::empty());
+    }
+
+    public function requestText(Payload $payload): TextResponse
+    {
+        throw new \BadMethodCallException();
+    }
+
+    public function requestStream(Payload $payload, ?callable $decoder = null): \Iterator
+    {
+        throw new \BadMethodCallException();
+    }
+}

--- a/packages/anthropic-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -34,6 +34,7 @@ final class ModelCapabilitiesTest extends TestCase
         yield 'claude-opus-5' => ['claude-opus-5', false];
         yield 'claude-sonnet-5' => ['claude-sonnet-5', false];
         yield 'claude-fable-5' => ['claude-fable-5', false];
+        yield 'claude-mythos-preview' => ['claude-mythos-preview', false];
     }
 
     #[DataProvider('samplingProvider')]
@@ -53,6 +54,7 @@ final class ModelCapabilitiesTest extends TestCase
         yield 'claude-opus-4-8' => ['claude-opus-4-8', true];
         yield 'claude-sonnet-5' => ['claude-sonnet-5', true];
         yield 'claude-fable-5' => ['claude-fable-5', true];
+        yield 'claude-mythos-preview' => ['claude-mythos-preview', true];
     }
 
     #[DataProvider('thinkingProvider')]
@@ -73,6 +75,7 @@ final class ModelCapabilitiesTest extends TestCase
         yield 'claude-opus-5' => ['claude-opus-5', true];
         yield 'claude-sonnet-5' => ['claude-sonnet-5', true];
         yield 'claude-fable-5' => ['claude-fable-5', true];
+        yield 'claude-mythos-preview' => ['claude-mythos-preview', true];
     }
 
     #[DataProvider('thinksByDefaultProvider')]
@@ -92,6 +95,7 @@ final class ModelCapabilitiesTest extends TestCase
         yield 'claude-sonnet-5' => ['claude-sonnet-5', true];
         yield 'claude-fable-5' => ['claude-fable-5', false];
         yield 'claude-mythos-5' => ['claude-mythos-5', false];
+        yield 'claude-mythos-preview' => ['claude-mythos-preview', false];
     }
 
     #[DataProvider('disabledThinkingProvider')]

--- a/packages/anthropic-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\AnthropicAdapter\Tests\Unit\Chat;
+
+use ModelflowAi\Anthropic\Model;
+use ModelflowAi\AnthropicAdapter\Chat\ModelCapabilities;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ModelCapabilitiesTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function samplingProvider(): \Generator
+    {
+        yield 'claude-3-haiku' => [Model::CLAUDE_3_HAIKU->value, true];
+        yield 'claude-haiku-4-5 snapshot' => ['claude-haiku-4-5-20251001', true];
+        yield 'claude-sonnet-4-6' => ['claude-sonnet-4-6', true];
+        yield 'claude-opus-4-6' => ['claude-opus-4-6', true];
+        yield 'claude-opus-4-7' => ['claude-opus-4-7', false];
+        yield 'claude-opus-4-8' => ['claude-opus-4-8', false];
+        yield 'claude-opus-5' => ['claude-opus-5', false];
+        yield 'claude-sonnet-5' => ['claude-sonnet-5', false];
+        yield 'claude-fable-5' => ['claude-fable-5', false];
+    }
+
+    #[DataProvider('samplingProvider')]
+    public function testSupportsSampling(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsSampling($model));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function thinkingProvider(): \Generator
+    {
+        yield 'claude-3-haiku' => [Model::CLAUDE_3_HAIKU->value, false];
+        yield 'claude-haiku-4-5 snapshot' => ['claude-haiku-4-5-20251001', false];
+        yield 'claude-sonnet-4-6' => ['claude-sonnet-4-6', true];
+        yield 'claude-opus-4-8' => ['claude-opus-4-8', true];
+        yield 'claude-sonnet-5' => ['claude-sonnet-5', true];
+        yield 'claude-fable-5' => ['claude-fable-5', true];
+    }
+
+    #[DataProvider('thinkingProvider')]
+    public function testSupportsThinking(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsThinking($model));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function thinksByDefaultProvider(): \Generator
+    {
+        yield 'claude-3-haiku' => [Model::CLAUDE_3_HAIKU->value, false];
+        yield 'claude-sonnet-4-6' => ['claude-sonnet-4-6', false];
+        yield 'claude-opus-4-7' => ['claude-opus-4-7', false];
+        yield 'claude-opus-4-8' => ['claude-opus-4-8', false];
+        yield 'claude-opus-5' => ['claude-opus-5', true];
+        yield 'claude-sonnet-5' => ['claude-sonnet-5', true];
+        yield 'claude-fable-5' => ['claude-fable-5', true];
+    }
+
+    #[DataProvider('thinksByDefaultProvider')]
+    public function testThinksByDefault(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::thinksByDefault($model));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function disabledThinkingProvider(): \Generator
+    {
+        yield 'claude-3-haiku' => [Model::CLAUDE_3_HAIKU->value, false];
+        yield 'claude-opus-4-8' => ['claude-opus-4-8', true];
+        yield 'claude-opus-5' => ['claude-opus-5', true];
+        yield 'claude-sonnet-5' => ['claude-sonnet-5', true];
+        yield 'claude-fable-5' => ['claude-fable-5', false];
+        yield 'claude-mythos-5' => ['claude-mythos-5', false];
+    }
+
+    #[DataProvider('disabledThinkingProvider')]
+    public function testSupportsDisabledThinking(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsDisabledThinking($model));
+    }
+}

--- a/packages/anthropic/src/Resources/MessagesInterface.php
+++ b/packages/anthropic/src/Resources/MessagesInterface.php
@@ -39,6 +39,7 @@ use ModelflowAi\Anthropic\Responses\Messages\CreateStreamedResponse;
  *         schema: array<string, mixed>,
  *     }
  * }
+ * @phpstan-type Thinking array{type: "adaptive"|"disabled", display?: "summarized"|"omitted"}
  * @phpstan-type Parameters array{
  *     model: string,
  *     messages: Message[],
@@ -49,6 +50,7 @@ use ModelflowAi\Anthropic\Responses\Messages\CreateStreamedResponse;
  *     temperature?: float,
  *     top_k?: int,
  *     top_p?: float,
+ *     thinking?: Thinking,
  *     output_config?: OutputConfig,
  * }
  */

--- a/packages/anthropic/src/Resources/MessagesInterface.php
+++ b/packages/anthropic/src/Resources/MessagesInterface.php
@@ -39,7 +39,9 @@ use ModelflowAi\Anthropic\Responses\Messages\CreateStreamedResponse;
  *         schema: array<string, mixed>,
  *     }
  * }
- * @phpstan-type Thinking array{type: "adaptive"|"disabled", display?: "summarized"|"omitted"}
+ * @phpstan-type Thinking array{type: "adaptive", display?: "summarized"|"omitted"}
+ *     |array{type: "disabled"}
+ *     |array{type: "enabled", budget_tokens: int, display?: "summarized"|"omitted"}
  * @phpstan-type Parameters array{
  *     model: string,
  *     messages: Message[],


### PR DESCRIPTION
Anthropic changed the request surface with the newer Claude generations, and the API answers with a 400 instead of ignoring an unsupported field. The adapter currently talks to every model the same way, which breaks in two directions:

* **Sampling is rejected since Opus 4.7.** `temperature` is forwarded whenever the caller sets it, so a request against `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5` or `claude-fable-5` fails with a 400.
* **`thinking` is never sent.** On Opus 5, Sonnet 5, Fable 5 and Mythos 5 omitting it means adaptive thinking, so simply pointing an existing configuration at a newer model silently adds thinking tokens and latency to every request — billed as output tokens.

## What this does

`ModelCapabilities` keeps the per generation matrix in one place: which models still accept sampling, which accept `thinking`, which think by default, and which (Fable, Mythos) reject `thinking: disabled`.

`AnthropicChatAdapter` uses it to

* drop the `temperature` option for models that reject it, with an `E_USER_WARNING` in the same style as the existing unsupported `seed` option, and
* send `thinking: {"type": "disabled"}` for the models that would otherwise think.

The result is that upgrading a model id does not change the billing profile of a request. Adaptive thinking is available as an opt in through the new `ThinkingModeEnum` on both `AnthropicChatAdapter` and `AnthropicChatAdapterFactory`.

Thinking is adapter configuration rather than a request option on purpose — `AIChatRequest` validates its option keys against a fixed list, so a request option would have meant a matching change in `modelflow-ai/chat`.

## Notes

* `packages/anthropic` only gains `thinking` in the `Parameters` phpstan type.
* `CapturingTransport` was added because the mock transport matches payloads partially and therefore cannot express "this field must not be sent".
* `composer test` and `composer lint` are green in both packages (60 and 22 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional adaptive or disabled thinking modes for supported Anthropic models.
  * Automatically applies model-specific defaults and validates unsupported configurations.
  * Omits incompatible temperature settings for models without sampling support.
  * Added support for configuring thinking options in message requests.

* **Bug Fixes**
  * Prevented unsupported thinking and temperature parameters from being sent to Anthropic models.
  * Added warnings for invalid or incompatible configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->