### PR TITLE
Fix the lint pipeline on the current rector release

### DIFF
--- a/integrations/symfony/composer.json
+++ b/integrations/symfony/composer.json
@@ -61,7 +61,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0 || ^12.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/yaml": "^6.2 | ^7.0 | ^8.0",
         "symfony/filesystem": "^6.2 | ^7.0 | ^8.0",
         "asapo/remove-vendor-plugin": "^0.1"

--- a/integrations/symfony/composer.lock
+++ b/integrations/symfony/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8b0338c73406dd04b0a5115cbf2bf58",
+    "content-hash": "4248737c6bdf0f17bfcff07cd5f9411f",
     "packages": [
         {
             "name": "psr/cache",
@@ -2901,7 +2901,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/anthropic",
-                "reference": "6c9bc35ea5b1275eb3a0010ded3e96b16c764c5f"
+                "reference": "07a89e0ad9aae3b2717eee5718163ac03053b3a8"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -2917,7 +2917,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -3000,7 +3000,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/anthropic-adapter",
-                "reference": "6f3b6131bfbd95d428b7c37776cc49c081610b57"
+                "reference": "572f5536983a78c841cdd12d0b3dfa666d2979b7"
             },
             "require": {
                 "modelflow-ai/anthropic": "^0.4",
@@ -3017,7 +3017,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -3099,7 +3099,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -3115,7 +3115,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -3195,7 +3195,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -3214,7 +3214,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -3307,7 +3307,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/completion",
-                "reference": "b11bf4474cb972630f8e2c4f761de0afbacd036f"
+                "reference": "6b24d8f88ef3d188c60bbfe626df5266059a3cd0"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -3325,7 +3325,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -3412,7 +3412,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -3426,7 +3426,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -3506,7 +3506,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -3523,7 +3523,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -3614,7 +3614,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/experts",
-                "reference": "5f169772cf5a78fa1c32bd70ac69e4bb5723f30e"
+                "reference": "5eba7a3a2cbe96ef111ac9a35d76cd31be641872"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -3629,7 +3629,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -3716,7 +3716,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/fireworksai-adapter",
-                "reference": "0a8f1df90895ac9410cf4da066f4022ba59ba83c"
+                "reference": "22eef1f3f7e11a26b392889f9ebdd06ccacc7d17"
             },
             "require": {
                 "nyholm/psr7": "^1.8",
@@ -3739,7 +3739,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.1",
                 "symfony/console": "^7.1",
                 "symfony/dotenv": "^7.1"
@@ -3829,10 +3829,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/google-gemini-adapter",
-                "reference": "978e4d24ecec6c954865aba28eb5e7b40fbcfa48"
+                "reference": "329d384e4d217f735da5d096820faedbcc546b25"
             },
             "require": {
-                "google-gemini-php/client": "^2.0",
+                "google-gemini-php/client": "^2.5",
                 "nyholm/psr7": "^1.8",
                 "php": "^8.2",
                 "php-http/discovery": "^1.0",
@@ -3850,7 +3850,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.1 || ^8.0",
                 "symfony/http-client": "^7.0 || ^8.0"
             },
@@ -3933,7 +3933,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/image",
-                "reference": "b61135f6b8d2344cd5a09e9d534d7f7887ec5f68"
+                "reference": "4d6be440c01189d973012053d43fbf12835a347e"
             },
             "require": {
                 "modelflow-ai/decision-tree": "^0.4",
@@ -3949,7 +3949,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "suggest": {
@@ -4036,7 +4036,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/mistral",
-                "reference": "7068ca161d9dd1acc08ea9c7b7a49da9aa60ea4b"
+                "reference": "0bf60d81b1b81655916658aafe7fa1e4bf0ee1fc"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -4052,7 +4052,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -4135,7 +4135,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/mistral-adapter",
-                "reference": "48ee85751b2d7ace7df2f8c8fcc8aafa8c80d18b"
+                "reference": "7dbdcc653eea5b49d625b95c77d9f7d4b7f5b79c"
             },
             "require": {
                 "modelflow-ai/mistral": "^0.4",
@@ -4153,7 +4153,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.1 || ^8.0"
             },
@@ -4239,7 +4239,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/ollama",
-                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
+                "reference": "db638557428600c9d5867ff3713a0dc8813e4129"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -4255,7 +4255,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -4337,7 +4337,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/ollama-adapter",
-                "reference": "92858069e82c52d17a2e31ddb8a5597bb2d92be9"
+                "reference": "f869673b7c297465973ec0730c4e4909f2674737"
             },
             "require": {
                 "modelflow-ai/ollama": "^0.4",
@@ -4357,7 +4357,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
@@ -4444,7 +4444,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/openai-adapter",
-                "reference": "d85fd3eb8a8d43772eb14f47b3007c6d169f7199"
+                "reference": "5d90b4b6e403315a37b8994d078dcf0dac64b190"
             },
             "require": {
                 "nyholm/psr7": "^1.8",
@@ -4466,7 +4466,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4",
                 "symfony/console": "^7.1",
                 "symfony/dotenv": "^7.1"
@@ -4556,7 +4556,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -4569,7 +4569,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -4651,7 +4651,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/qdrant-embeddings-store",
-                "reference": "7d6f6b13eb077719db027d376dc5df720412886e"
+                "reference": "9fa2835b4ba1bd1a3a30a741aa1a78df97b0c034"
             },
             "require": {
                 "hkulekci/qdrant": "^0.5",
@@ -4672,7 +4672,7 @@
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
                 "ramsey/uuid": "^4.7",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.0 || ^8.0",
                 "symfony/dotenv": "^7.1 || ^8.0"
             },
@@ -5401,8 +5401,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -5459,7 +5459,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -6198,21 +6198,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -6246,7 +6246,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -6254,7 +6254,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/anthropic-adapter/composer.json
+++ b/packages/anthropic-adapter/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/dotenv": "^7.1 || ^8.0",

--- a/packages/anthropic-adapter/composer.lock
+++ b/packages/anthropic-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ea8f7b6297efcac0a7514f8c5b6b205",
+    "content-hash": "e777c2fabb0e63640ba3fb3c8fd860c6",
     "packages": [
         {
             "name": "modelflow-ai/anthropic",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../anthropic",
-                "reference": "6c9bc35ea5b1275eb3a0010ded3e96b16c764c5f"
+                "reference": "07a89e0ad9aae3b2717eee5718163ac03053b3a8"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -28,7 +28,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -111,7 +111,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -127,7 +127,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -931,7 +931,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -950,7 +950,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1043,7 +1043,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -1057,7 +1057,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1137,7 +1137,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -1150,7 +1150,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1925,8 +1925,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1983,7 +1983,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2486,21 +2486,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2534,7 +2534,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2542,7 +2542,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/anthropic/composer.json
+++ b/packages/anthropic/composer.json
@@ -36,7 +36,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/dotenv": "^6.4 || ^7.0 || ^8.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",

--- a/packages/anthropic/composer.lock
+++ b/packages/anthropic/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bb8db8ac667ea187815c92218f71962",
+    "content-hash": "0d5fa6e5211e072ff0315f98b0c99f02",
     "packages": [
         {
             "name": "modelflow-ai/api-client",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -28,7 +28,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1525,8 +1525,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1583,7 +1583,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2086,21 +2086,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2134,7 +2134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2142,7 +2142,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/anthropic/src/Resources/Messages.php
+++ b/packages/anthropic/src/Resources/Messages.php
@@ -72,10 +72,11 @@ final readonly class Messages implements MessagesInterface
 
                 $eventName = \trim(\substr($event[0], 6));
                 $data = \trim(\substr($event[1], 5));
-
                 if ('ping' === $eventName) {
                     continue;
-                } elseif ('message_start' === $eventName) {
+                }
+
+                if ('message_start' === $eventName) {
                     /** @var array{
                      *     message: array{
                      *          id: string,
@@ -90,7 +91,6 @@ final readonly class Messages implements MessagesInterface
                      * } $object */
                     $object = \json_decode($data, true);
                     $message = $object['message'];
-
                     yield $message;
                 } elseif ('content_block_start' === $eventName) {
                     /** @var array{
@@ -123,8 +123,6 @@ final readonly class Messages implements MessagesInterface
 
                     // @phpstan-ignore-next-line
                     yield [...$message, 'content' => ['index' => $object['index'], ...$object['delta']]];
-                } elseif ('content_block_stop' === $eventName) {
-                    continue;
                 } elseif ('message_delta' === $eventName) {
                     /** @var array{
                      *     delta: array{
@@ -147,6 +145,8 @@ final readonly class Messages implements MessagesInterface
                     $message = [...$message, ...$object['delta']];
 
                     yield $message;
+                } elseif ('content_block_stop' === $eventName) {
+                    continue;
                 } elseif ('message_stop' === $eventName) {
                     continue;
                 }

--- a/packages/anthropic/src/Responses/Messages/CreateResponseContent.php
+++ b/packages/anthropic/src/Responses/Messages/CreateResponseContent.php
@@ -36,7 +36,8 @@ final readonly class CreateResponseContent
                 $attributes['type'],
                 $attributes['text'],
             );
-        } elseif ('tool_use' === $attributes['type']) {
+        }
+        if ('tool_use' === $attributes['type']) {
             return new self(
                 $attributes['type'],
                 null,

--- a/packages/api-client/composer.json
+++ b/packages/api-client/composer.json
@@ -34,7 +34,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "asapo/remove-vendor-plugin": "^0.1"

--- a/packages/api-client/composer.lock
+++ b/packages/api-client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87db81479470e57bc1162bd31135c0d3",
+    "content-hash": "cc04f2f0f49144bddbb5df6cf326a3db",
     "packages": [
         {
             "name": "psr/container",
@@ -1429,8 +1429,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1487,7 +1487,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1990,21 +1990,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2038,7 +2038,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2046,7 +2046,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/chat/composer.json
+++ b/packages/chat/composer.json
@@ -49,7 +49,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/dotenv": "^7.2 || ^8.0",

--- a/packages/chat/composer.lock
+++ b/packages/chat/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "582ad6d212414ca69a1e862ce67c7fe6",
+    "content-hash": "9c5e38c64bccf34120e2aa60a58f643d",
     "packages": [
         {
             "name": "modelflow-ai/decision-tree",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -26,7 +26,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -457,7 +457,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -470,7 +470,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1245,8 +1245,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1303,7 +1303,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1806,21 +1806,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1854,7 +1854,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1862,7 +1862,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/chat/src/Util/Json/OptimisticJsonParser.php
+++ b/packages/chat/src/Util/Json/OptimisticJsonParser.php
@@ -116,7 +116,7 @@ class OptimisticJsonParser
         // Trailing comma before end of string (will be followed by structure closure)
         $trimmed = \rtrim($jsonString);
         if (\preg_match('/,\s*$/', $trimmed)) {
-            $jsonString = \preg_replace('/,\s*$/', '', $trimmed) ?? $trimmed;
+            return \preg_replace('/,\s*$/', '', $trimmed) ?? $trimmed;
         }
 
         return $jsonString;

--- a/packages/completion/composer.json
+++ b/packages/completion/composer.json
@@ -43,7 +43,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/dotenv": "^7.2 || ^8.0"

--- a/packages/completion/composer.lock
+++ b/packages/completion/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "319c69d7c206dee7c7d11ab0aca85b77",
+    "content-hash": "9202d4af2ebafa2d70352541d5d6aab8",
     "packages": [
         {
             "name": "modelflow-ai/decision-tree",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -26,7 +26,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -385,7 +385,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -404,7 +404,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -497,7 +497,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -510,7 +510,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1285,8 +1285,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1343,7 +1343,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1846,21 +1846,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1894,7 +1894,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1902,7 +1902,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/decision-tree/composer.json
+++ b/packages/decision-tree/composer.json
@@ -33,7 +33,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/console": "^7.1 || ^8.0",
         "asapo/remove-vendor-plugin": "^0.1"
     },

--- a/packages/decision-tree/composer.lock
+++ b/packages/decision-tree/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9654a898229b763624d9e979dfc74b6",
+    "content-hash": "6c83b395eb6c18ca84b1a15674854fe6",
     "packages": [],
     "packages-dev": [
         {
@@ -925,8 +925,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -983,7 +983,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1540,21 +1540,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1588,7 +1588,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1596,7 +1596,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/elasticsearch-embeddings-store/composer.json
+++ b/packages/elasticsearch-embeddings-store/composer.json
@@ -37,7 +37,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/cache": "^7.0 || ^8.0",
         "ramsey/uuid": "^4.7",
         "guzzlehttp/psr7": "^2.0",

--- a/packages/elasticsearch-embeddings-store/composer.lock
+++ b/packages/elasticsearch-embeddings-store/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8980f6369b52dc6b0db88ca2b53e6f0d",
+    "content-hash": "20c59f56f093e337889128e09693c4cf",
     "packages": [
         {
             "name": "elastic/transport",
@@ -462,7 +462,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -479,7 +479,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -2271,7 +2271,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -2287,7 +2287,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2367,7 +2367,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama",
-                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
+                "reference": "db638557428600c9d5867ff3713a0dc8813e4129"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -2383,7 +2383,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2465,7 +2465,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama-adapter",
-                "reference": "92858069e82c52d17a2e31ddb8a5597bb2d92be9"
+                "reference": "f869673b7c297465973ec0730c4e4909f2674737"
             },
             "require": {
                 "modelflow-ai/ollama": "^0.4",
@@ -2485,7 +2485,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
@@ -2911,8 +2911,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2969,7 +2969,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -3627,21 +3627,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -3675,7 +3675,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -3683,7 +3683,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/embeddings/composer.json
+++ b/packages/embeddings/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/cache": "^6.4 || ^7.0 || ^8.0"

--- a/packages/embeddings/composer.lock
+++ b/packages/embeddings/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9ac3b724ae10da2f58d95d264b3bba9",
+    "content-hash": "4182c7d5c382f19c5a01cf99a6ca8d56",
     "packages": [
         {
             "name": "psr/cache",
@@ -1018,7 +1018,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -1034,7 +1034,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1114,7 +1114,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama",
-                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
+                "reference": "db638557428600c9d5867ff3713a0dc8813e4129"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -1130,7 +1130,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1212,7 +1212,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama-adapter",
-                "reference": "92858069e82c52d17a2e31ddb8a5597bb2d92be9"
+                "reference": "f869673b7c297465973ec0730c4e4909f2674737"
             },
             "require": {
                 "modelflow-ai/ollama": "^0.4",
@@ -1232,7 +1232,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
@@ -2012,8 +2012,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2070,7 +2070,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2624,21 +2624,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2672,7 +2672,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2680,7 +2680,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/experts/composer.json
+++ b/packages/experts/composer.json
@@ -39,7 +39,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/dotenv": "^7.2 || ^8.0",

--- a/packages/experts/composer.lock
+++ b/packages/experts/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c317d227f4d2b63c481b849eb9a3e889",
+    "content-hash": "58a1ad0be7a8b0790eebba03a95f8299",
     "packages": [
         {
             "name": "modelflow-ai/chat",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -31,7 +31,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -124,7 +124,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -138,7 +138,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1262,8 +1262,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1320,7 +1320,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1823,21 +1823,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1871,7 +1871,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1879,7 +1879,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/fireworksai-adapter/composer.json
+++ b/packages/fireworksai-adapter/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy": "^1.0@dev",
         "jangregor/phpstan-prophecy": "^2.0",
         "phpspec/prophecy-phpunit": "^2.2",

--- a/packages/fireworksai-adapter/composer.lock
+++ b/packages/fireworksai-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5edcb019c63576eb9cf701401bb341e1",
+    "content-hash": "e595889abbbc72cd61cb42248076097b",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1166,7 +1166,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1259,7 +1259,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../completion",
-                "reference": "b11bf4474cb972630f8e2c4f761de0afbacd036f"
+                "reference": "6b24d8f88ef3d188c60bbfe626df5266059a3cd0"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1277,7 +1277,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1364,7 +1364,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -1378,7 +1378,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1458,7 +1458,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -1475,7 +1475,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -1566,7 +1566,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../image",
-                "reference": "b61135f6b8d2344cd5a09e9d534d7f7887ec5f68"
+                "reference": "4d6be440c01189d973012053d43fbf12835a347e"
             },
             "require": {
                 "modelflow-ai/decision-tree": "^0.4",
@@ -1582,7 +1582,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "suggest": {
@@ -1669,7 +1669,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -1682,7 +1682,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2457,8 +2457,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2515,7 +2515,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -3071,21 +3071,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -3119,7 +3119,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -3127,7 +3127,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/google-gemini-adapter/composer.json
+++ b/packages/google-gemini-adapter/composer.json
@@ -39,7 +39,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/dotenv": "^7.1 || ^8.0",

--- a/packages/google-gemini-adapter/composer.lock
+++ b/packages/google-gemini-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "318b3abce160e9c83b919c1445379957",
+    "content-hash": "e65f859e834dacec2c53bac9707cb535",
     "packages": [
         {
             "name": "google-gemini-php/client",
@@ -634,7 +634,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -653,7 +653,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -746,7 +746,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -760,7 +760,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -840,7 +840,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -853,7 +853,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1628,8 +1628,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1686,7 +1686,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2294,21 +2294,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2342,7 +2342,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2350,7 +2350,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/image/composer.json
+++ b/packages/image/composer.json
@@ -38,7 +38,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/console": "^7.1 || ^8.0",
         "asapo/remove-vendor-plugin": "^0.1"
     },

--- a/packages/image/composer.lock
+++ b/packages/image/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3172a541f247edf8535d3c644e8b057c",
+    "content-hash": "7522f94c8f7f020353057e2df5a90313",
     "packages": [
         {
             "name": "modelflow-ai/decision-tree",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -26,7 +26,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1078,8 +1078,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1136,7 +1136,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1693,21 +1693,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1741,7 +1741,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1749,7 +1749,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/mistral-adapter/composer.json
+++ b/packages/mistral-adapter/composer.json
@@ -37,7 +37,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "symfony/dotenv": "^7.1 || ^8.0",

--- a/packages/mistral-adapter/composer.lock
+++ b/packages/mistral-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0175f4618ecebf26f3a38c6a3d64d38",
+    "content-hash": "72566240cc177beeb2df9e3fd57e68b2",
     "packages": [
         {
             "name": "modelflow-ai/api-client",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -28,7 +28,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -108,7 +108,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../mistral",
-                "reference": "7068ca161d9dd1acc08ea9c7b7a49da9aa60ea4b"
+                "reference": "0bf60d81b1b81655916658aafe7fa1e4bf0ee1fc"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -124,7 +124,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -931,7 +931,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -950,7 +950,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1043,7 +1043,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -1057,7 +1057,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1137,7 +1137,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -1154,7 +1154,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -1245,7 +1245,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -1258,7 +1258,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2033,8 +2033,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2091,7 +2091,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2647,21 +2647,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2695,7 +2695,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2703,7 +2703,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/mistral/composer.json
+++ b/packages/mistral/composer.json
@@ -36,7 +36,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/dotenv": "^6.4 || ^7.0 || ^8.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",

--- a/packages/mistral/composer.lock
+++ b/packages/mistral/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e2d84bc542e9760e016d6b8e7ba241d",
+    "content-hash": "ef8166c75517ab2752541872a64a14b2",
     "packages": [
         {
             "name": "modelflow-ai/api-client",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -28,7 +28,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1525,8 +1525,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1583,7 +1583,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2086,21 +2086,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2134,7 +2134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2142,7 +2142,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/ollama-adapter/composer.json
+++ b/packages/ollama-adapter/composer.json
@@ -40,7 +40,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "jangregor/phpstan-prophecy": "^2.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "symfony/dotenv": "^7.2 || ^8.0",

--- a/packages/ollama-adapter/composer.lock
+++ b/packages/ollama-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b0b9cbfd08e244de1fd156acbddadb1",
+    "content-hash": "6794892029872821616b1884e3cf9fdb",
     "packages": [
         {
             "name": "modelflow-ai/api-client",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -28,7 +28,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -108,7 +108,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama",
-                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
+                "reference": "db638557428600c9d5867ff3713a0dc8813e4129"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -124,7 +124,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -930,7 +930,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -949,7 +949,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1042,7 +1042,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../completion",
-                "reference": "b11bf4474cb972630f8e2c4f761de0afbacd036f"
+                "reference": "6b24d8f88ef3d188c60bbfe626df5266059a3cd0"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1060,7 +1060,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -1161,7 +1161,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1241,7 +1241,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -1258,7 +1258,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -1349,7 +1349,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -1362,7 +1362,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2137,8 +2137,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2195,7 +2195,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2751,21 +2751,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2799,7 +2799,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2807,7 +2807,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/ollama/composer.json
+++ b/packages/ollama/composer.json
@@ -36,7 +36,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "jangregor/phpstan-prophecy": "^2.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "asapo/remove-vendor-plugin": "^0.1"

--- a/packages/ollama/composer.lock
+++ b/packages/ollama/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "236c747e30f85c4e55a906b2f1e91321",
+    "content-hash": "3edb42d69b8bf1cb23ab1baf62b4bdaf",
     "packages": [
         {
             "name": "modelflow-ai/api-client",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -28,7 +28,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1525,8 +1525,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1583,7 +1583,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2086,21 +2086,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -2134,7 +2134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -2142,7 +2142,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/openai-adapter/composer.json
+++ b/packages/openai-adapter/composer.json
@@ -41,7 +41,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy": "^1.0@dev",
         "jangregor/phpstan-prophecy": "^2.0",
         "phpspec/prophecy-phpunit": "^2.2",

--- a/packages/openai-adapter/composer.lock
+++ b/packages/openai-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f5a254db82a50c11ffa1538cef3f6ef",
+    "content-hash": "efbb26cc879c392c172bfb644387bbd1",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1166,7 +1166,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1259,7 +1259,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -1273,7 +1273,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1353,7 +1353,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -1370,7 +1370,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -1461,7 +1461,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../image",
-                "reference": "b61135f6b8d2344cd5a09e9d534d7f7887ec5f68"
+                "reference": "4d6be440c01189d973012053d43fbf12835a347e"
             },
             "require": {
                 "modelflow-ai/decision-tree": "^0.4",
@@ -1477,7 +1477,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "suggest": {
@@ -1564,7 +1564,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../prompt-template",
-                "reference": "f134851c1d83a6d6d532f7828ccb898b741bf6d4"
+                "reference": "ac90008a05ae122ff02d0e9046c8ed77cec05268"
             },
             "require": {
                 "modelflow-ai/chat": "^0.4",
@@ -1577,7 +1577,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2352,8 +2352,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2410,7 +2410,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2966,21 +2966,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -3014,7 +3014,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -3022,7 +3022,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
@@ -543,8 +543,8 @@ final class OpenaiChatAdapterTest extends TestCase
 
     public function testSupportResponseFormatWithSupportedInstance(): void
     {
-        $client = $this->createMock(ClientContract::class);
-        $unsupportedFormat = $this->createMock(JsonSchemaResponseFormat::class);
+        $client = $this->createStub(ClientContract::class);
+        $unsupportedFormat = $this->createStub(JsonSchemaResponseFormat::class);
 
         $adapter = new OpenaiChatAdapter($client);
 
@@ -553,8 +553,8 @@ final class OpenaiChatAdapterTest extends TestCase
 
     public function testSupportResponseFormatWithUnsupportedInstance(): void
     {
-        $client = $this->createMock(ClientContract::class);
-        $unsupportedFormat = $this->createMock(ResponseFormatInterface::class);
+        $client = $this->createStub(ClientContract::class);
+        $unsupportedFormat = $this->createStub(ResponseFormatInterface::class);
 
         $adapter = new OpenaiChatAdapter($client);
 

--- a/packages/prompt-template/composer.json
+++ b/packages/prompt-template/composer.json
@@ -35,7 +35,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "asapo/remove-vendor-plugin": "^0.1"
     },
     "scripts": {

--- a/packages/prompt-template/composer.lock
+++ b/packages/prompt-template/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc41aab98a9a535e7700c8fba3eba927",
+    "content-hash": "64e8679cb92f26dda74da816f4afce86",
     "packages": [
         {
             "name": "modelflow-ai/chat",
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -31,7 +31,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -124,7 +124,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -138,7 +138,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -729,8 +729,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -787,7 +787,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1290,21 +1290,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1338,7 +1338,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1346,7 +1346,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/qdrant-embeddings-store/composer.json
+++ b/packages/qdrant-embeddings-store/composer.json
@@ -38,7 +38,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/cache": "^7.0 || ^8.0",
         "ramsey/uuid": "^4.7",
         "symfony/dotenv": "^7.1 || ^8.0",

--- a/packages/qdrant-embeddings-store/composer.lock
+++ b/packages/qdrant-embeddings-store/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ffc2de03764138601e1380f000aa119",
+    "content-hash": "f3131f6357f6711202dcd021e7fc9bf3",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
+                "reference": "8ca6b5fe7d6a0c7c88a20cbccb3e7356ccac2c76"
             },
             "require": {
                 "php": "^8.2",
@@ -416,7 +416,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^6.4 || ^7.0 || ^8.0"
             },
             "suggest": {
@@ -1944,7 +1944,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -1960,7 +1960,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2040,7 +2040,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama",
-                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
+                "reference": "db638557428600c9d5867ff3713a0dc8813e4129"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -2056,7 +2056,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2138,7 +2138,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama-adapter",
-                "reference": "92858069e82c52d17a2e31ddb8a5597bb2d92be9"
+                "reference": "f869673b7c297465973ec0730c4e4909f2674737"
             },
             "require": {
                 "modelflow-ai/ollama": "^0.4",
@@ -2158,7 +2158,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
@@ -2584,8 +2584,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -2642,7 +2642,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -3300,21 +3300,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -3348,7 +3348,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -3356,7 +3356,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/packages/tools/composer.json
+++ b/packages/tools/composer.json
@@ -40,7 +40,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "phpspec/prophecy-phpunit": "^2.2",
         "jangregor/phpstan-prophecy": "^2.0",
         "asapo/remove-vendor-plugin": "^0.1"

--- a/packages/tools/composer.lock
+++ b/packages/tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b5f4809168e03f51095aa0b53e498ec",
+    "content-hash": "e26958add74ab75baaa6298948b7c2d0",
     "packages": [
         {
             "name": "psr/container",
@@ -1371,8 +1371,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
-                "reference": "e336b2b9dd4f2c8b6af3a0b46d75bbf1ea0932e5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
+                "reference": "f5e1836289d12aa3f59eaa3d1dc9e439bd85d5ea",
                 "shasum": ""
             },
             "require": {
@@ -1429,7 +1429,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T19:08:05+00:00"
+            "time": "2026-08-20T14:28:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1932,21 +1932,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1980,7 +1980,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -1988,7 +1988,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/projects/chat/composer.json
+++ b/projects/chat/composer.json
@@ -46,7 +46,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0 || ^12.0",
-        "rector/rector": "^2.0",
+        "rector/rector": "^2.6",
         "symfony/debug-bundle": "^7.0 || ^8.0",
         "symfony/maker-bundle": "^1.54",
         "symfony/monolog-bundle": "^4.0",

--- a/projects/chat/composer.lock
+++ b/projects/chat/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e4ef2b4ddcf391ce62a848179cc27f7",
+    "content-hash": "ef8227fe24cfb74f3313a68095f56181",
     "packages": [
         {
             "name": "brick/math",
@@ -1339,7 +1339,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/anthropic",
-                "reference": "6c9bc35ea5b1275eb3a0010ded3e96b16c764c5f"
+                "reference": "07a89e0ad9aae3b2717eee5718163ac03053b3a8"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -1355,7 +1355,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -1438,7 +1438,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/anthropic-adapter",
-                "reference": "6f3b6131bfbd95d428b7c37776cc49c081610b57"
+                "reference": "572f5536983a78c841cdd12d0b3dfa666d2979b7"
             },
             "require": {
                 "modelflow-ai/anthropic": "^0.4",
@@ -1455,7 +1455,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1537,7 +1537,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/api-client",
-                "reference": "9adb5673aaf0c41b72ceb599e1526cdac8860a0b"
+                "reference": "6a54678b4000e5dedfa00e2abcdfd3aabde7c9f0"
             },
             "require": {
                 "php": "^8.2",
@@ -1553,7 +1553,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -1633,7 +1633,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/chat",
-                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
+                "reference": "9d0c1e10c9fb55ffd417e2660110b0a0128b7924"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1652,7 +1652,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
             "type": "library",
@@ -1745,7 +1745,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/decision-tree",
-                "reference": "5513626695500dc6be4481b7c52530b54124c0aa"
+                "reference": "6821da1380fd56b31d76972a273eb12793fcdfa9"
             },
             "require": {
                 "php": "^8.2"
@@ -1759,7 +1759,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "type": "library",
@@ -1839,7 +1839,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/fireworksai-adapter",
-                "reference": "0a8f1df90895ac9410cf4da066f4022ba59ba83c"
+                "reference": "22eef1f3f7e11a26b392889f9ebdd06ccacc7d17"
             },
             "require": {
                 "nyholm/psr7": "^1.8",
@@ -1862,7 +1862,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.1",
                 "symfony/console": "^7.1",
                 "symfony/dotenv": "^7.1"
@@ -1952,10 +1952,10 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/google-gemini-adapter",
-                "reference": "978e4d24ecec6c954865aba28eb5e7b40fbcfa48"
+                "reference": "329d384e4d217f735da5d096820faedbcc546b25"
             },
             "require": {
-                "google-gemini-php/client": "^2.0",
+                "google-gemini-php/client": "^2.5",
                 "nyholm/psr7": "^1.8",
                 "php": "^8.2",
                 "php-http/discovery": "^1.0",
@@ -1973,7 +1973,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^7.1 || ^8.0",
                 "symfony/http-client": "^7.0 || ^8.0"
             },
@@ -2056,7 +2056,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/image",
-                "reference": "b61135f6b8d2344cd5a09e9d534d7f7887ec5f68"
+                "reference": "4d6be440c01189d973012053d43fbf12835a347e"
             },
             "require": {
                 "modelflow-ai/decision-tree": "^0.4",
@@ -2072,7 +2072,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/console": "^7.1 || ^8.0"
             },
             "suggest": {
@@ -2159,7 +2159,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/mistral",
-                "reference": "7068ca161d9dd1acc08ea9c7b7a49da9aa60ea4b"
+                "reference": "0bf60d81b1b81655916658aafe7fa1e4bf0ee1fc"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -2175,7 +2175,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/dotenv": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -2258,7 +2258,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/mistral-adapter",
-                "reference": "48ee85751b2d7ace7df2f8c8fcc8aafa8c80d18b"
+                "reference": "7dbdcc653eea5b49d625b95c77d9f7d4b7f5b79c"
             },
             "require": {
                 "modelflow-ai/mistral": "^0.4",
@@ -2276,7 +2276,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.1 || ^8.0"
             },
@@ -2362,7 +2362,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/ollama",
-                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
+                "reference": "db638557428600c9d5867ff3713a0dc8813e4129"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -2378,7 +2378,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -2460,7 +2460,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/ollama-adapter",
-                "reference": "92858069e82c52d17a2e31ddb8a5597bb2d92be9"
+                "reference": "f869673b7c297465973ec0730c4e4909f2674737"
             },
             "require": {
                 "modelflow-ai/ollama": "^0.4",
@@ -2480,7 +2480,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4 || ^8.0",
                 "symfony/dotenv": "^7.2 || ^8.0"
             },
@@ -2567,7 +2567,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/openai-adapter",
-                "reference": "d85fd3eb8a8d43772eb14f47b3007c6d169f7199"
+                "reference": "5d90b4b6e403315a37b8994d078dcf0dac64b190"
             },
             "require": {
                 "nyholm/psr7": "^1.8",
@@ -2589,7 +2589,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/cache": "^7.4",
                 "symfony/console": "^7.1",
                 "symfony/dotenv": "^7.1"
@@ -2679,7 +2679,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../integrations/symfony",
-                "reference": "90d448c6bee6fc182268820bc84a3ca29a6a8d04"
+                "reference": "30abc6952a867faa174cd2b30b1d8c2c177aef82"
             },
             "require": {
                 "php": "^8.2",
@@ -2709,7 +2709,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0 || ^12.0",
-                "rector/rector": "^2.0",
+                "rector/rector": "^2.6",
                 "symfony/filesystem": "^6.2 | ^7.0 | ^8.0",
                 "symfony/yaml": "^6.2 | ^7.0 | ^8.0"
             },
@@ -2816,7 +2816,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../../packages/tools",
-                "reference": "ea6f2cd97d9faa295c28bce8a8d538001dcfd9e7"
+                "reference": "7a17f0b2605128801df5548f7c9a20fb85c652ae"
             },
             "require": {
                 "php": "^8.2",
@@ -2831,7 +2831,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^11.0",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.6"
             },
             "type": "library",
             "extra": {
@@ -9077,11 +9077,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.1",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
-                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -9137,7 +9137,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T14:44:12+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -9632,21 +9632,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
+                "reference": "7e46709996a4b3dc59e1d6ecbb6a38ace335bd58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -9680,7 +9680,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.3"
             },
             "funding": [
                 {
@@ -9688,7 +9688,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-08-18T22:01:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,6 @@ return static function (RectorConfig $rectorConfig, string $directory): void {
     $rectorConfig->sets([
         SetList::CODE_QUALITY,
         LevelSetList::UP_TO_PHP_82,
-        PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::COMPOSER_BASED,
     ]);
 };


### PR DESCRIPTION
Every `Lint true` job currently fails, in every package:

```
[ERROR] Undefined constant Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_100
```

That matrix entry is the only one running `dependency-versions: highest`, so it resolves rector 2.6.3, where rector-phpunit dropped the version specific sets (`PHPUNIT_40` … `PHPUNIT_120`). The committed lock files still pin 2.4.5, which is why a local `composer lint` stays green and CI does not.

## What this does

* `rector.php` uses `PHPUnitSetList::COMPOSER_BASED`, the set that replaced the version specific ones — it reads the PHPUnit version from `composer.json` and applies the rules bound to it.
* The `rector/rector` constraint moves from `^2.0` to `^2.6`, because `COMPOSER_BASED` does not exist before 2.6, and the lock files follow (`rector/rector` 2.4.5 → 2.6.3, and `phpstan/phpstan` 2.2.1 → 2.2.8 as its requirement). Nothing else changes version.
* The four source changes are what the newer `CODE_QUALITY` and PHPUnit rules apply to existing code: `RemoveAlwaysElseRector` turns an `else`/`elseif` that always follows a `continue` or `return` into an early exit, and `createMock` becomes `createStub` for two doubles that set no expectations.

## Verification

`composer test` and `composer lint` are green in all 20 packages and in the Symfony integration. The two embeddings store packages fail their bootstrap locally because Elasticsearch and Qdrant are not running; CI provides those services.

## Not covered

`projects/readme-generator` is pinned to `rector/rector ^0.18` through `phpstan ^1.10` and already crashes on PHP 8.4 inside the bundled phpstan phar, so its lint was broken before this change and stays broken. It is not part of the CI matrix. Bringing it up to date means upgrading its phpstan first, which belongs in its own change.
