### PR TITLE
Ask OpenAI and Google for the least reasoning the model allows

### DIFF
--- a/packages/google-gemini-adapter/composer.json
+++ b/packages/google-gemini-adapter/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "google-gemini-php/client": "^2.5",
+        "google-gemini-php/client": "^2.7.4",
         "php-http/discovery": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-client": "^1.0",

--- a/packages/google-gemini-adapter/composer.lock
+++ b/packages/google-gemini-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e65f859e834dacec2c53bac9707cb535",
+    "content-hash": "0057458e32f0e582ab7f8d112a60de06",
     "packages": [
         {
             "name": "google-gemini-php/client",

--- a/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
+++ b/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
@@ -23,12 +23,14 @@ use Gemini\Data\FunctionResponse;
 use Gemini\Data\GenerationConfig;
 use Gemini\Data\Part;
 use Gemini\Data\Schema;
+use Gemini\Data\ThinkingConfig;
 use Gemini\Data\ToolConfig;
 use Gemini\Enums\DataType;
 use Gemini\Enums\MimeType;
 use Gemini\Enums\Mode;
 use Gemini\Enums\ResponseMimeType;
 use Gemini\Enums\Role;
+use Gemini\Enums\ThinkingLevel;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
 use ModelflowAi\Chat\Adapter\AIChatAdapterInterface;
 use ModelflowAi\Chat\Request\AIChatRequest;
@@ -65,6 +67,7 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
     public function __construct(
         private ClientContract $client,
         private string $model,
+        private ?ThinkingLevel $thinkingLevel = null,
     ) {
     }
 
@@ -155,6 +158,8 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
             $responseMimeType = ResponseMimeType::APPLICATION_JSON;
         }
 
+        $thinkingConfig = $this->buildThinkingConfig();
+
         if (null !== $temperature) {
             Assert::float($temperature);
 
@@ -162,6 +167,7 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
                 temperature: $temperature,
                 responseMimeType: $responseMimeType,
                 responseSchema: $responseSchema,
+                thinkingConfig: $thinkingConfig,
             );
         }
 
@@ -169,10 +175,34 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
             return new GenerationConfig(
                 responseMimeType: $responseMimeType,
                 responseSchema: $responseSchema,
+                thinkingConfig: $thinkingConfig,
             );
         }
 
-        return new GenerationConfig();
+        return new GenerationConfig(
+            thinkingConfig: $thinkingConfig,
+        );
+    }
+
+    /**
+     * Gemini 3 thinks at medium level unless told otherwise, and every generated thought is billed
+     * as an output token. Ask for the lowest level the generation accepts; unlike other providers
+     * thinking cannot be turned off entirely.
+     */
+    private function buildThinkingConfig(): ?ThinkingConfig
+    {
+        if (!ModelCapabilities::supportsThinkingLevel($this->model)) {
+            if ($this->thinkingLevel instanceof ThinkingLevel) {
+                @\trigger_error(\sprintf('Thinking level is not supported by "%s".', $this->model), \E_USER_WARNING);
+            }
+
+            return null;
+        }
+
+        return new ThinkingConfig(
+            includeThoughts: false,
+            thinkingLevel: $this->thinkingLevel ?? ThinkingLevel::LOW,
+        );
     }
 
     /**

--- a/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapterFactory.php
+++ b/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapterFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ModelflowAi\GoogleGeminiAdapter\Chat;
 
 use Gemini\Contracts\ClientContract;
+use Gemini\Enums\ThinkingLevel;
 use ModelflowAi\Chat\Adapter\AIChatAdapterFactoryInterface;
 use ModelflowAi\Chat\Adapter\AIChatAdapterInterface;
 
@@ -21,6 +22,7 @@ final readonly class GoogleGeminiChatAdapterFactory implements AIChatAdapterFact
 {
     public function __construct(
         private ClientContract $client,
+        private ?ThinkingLevel $thinkingLevel = null,
     ) {
     }
 
@@ -29,6 +31,7 @@ final readonly class GoogleGeminiChatAdapterFactory implements AIChatAdapterFact
         return new GoogleGeminiChatAdapter(
             $this->client,
             $options['model'],
+            $this->thinkingLevel,
         );
     }
 }

--- a/packages/google-gemini-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/google-gemini-adapter/src/Chat/ModelCapabilities.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\GoogleGeminiAdapter\Chat;
+
+/**
+ * Thinking support across the Gemini generations.
+ *
+ * @see https://ai.google.dev/gemini-api/docs/thinking
+ */
+final class ModelCapabilities
+{
+    /**
+     * Models taking the `thinkingLevel` enum. Gemini 2.x expects a `thinkingBudget` in tokens
+     * instead, which this adapter does not send.
+     *
+     * @var list<string>
+     */
+    private const THINKING_LEVEL_SUPPORTED = [
+        'gemini-3',
+    ];
+
+    public static function supportsThinkingLevel(string $model): bool
+    {
+        // Both the bare id and the fully qualified "models/gemini-3.7-flash" form are in use.
+        $name = \str_starts_with($model, 'models/') ? \substr($model, 7) : $model;
+
+        foreach (self::THINKING_LEVEL_SUPPORTED as $candidate) {
+            // Covers the generation and its releases, such as "gemini-3.7-flash".
+            if ($name === $candidate || \str_starts_with($name, $candidate . '-') || \str_starts_with($name, $candidate . '.')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/google-gemini-adapter/src/ClientFactory.php
+++ b/packages/google-gemini-adapter/src/ClientFactory.php
@@ -43,6 +43,9 @@ class ClientFactory
 
         return \Gemini::factory()
             ->withApiKey($this->apiKey)
+            // The charset is redundant for application/json, but spelling it out costs nothing and
+            // rules the header out as a suspect when a response comes back with mangled characters.
+            ->withHttpHeader('Content-Type', 'application/json; charset=utf-8')
             ->withHttpClient($client)
             ->withStreamHandler(static fn (RequestInterface $request): ResponseInterface => $client->sendRequest($request))
             ->make();

--- a/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
@@ -18,11 +18,13 @@ use Gemini\Data\Content;
 use Gemini\Data\FunctionCall;
 use Gemini\Data\FunctionResponse;
 use Gemini\Data\GenerationConfig;
+use Gemini\Data\ThinkingConfig;
 use Gemini\Data\Tool;
 use Gemini\Enums\DataType;
 use Gemini\Enums\ModelType;
 use Gemini\Enums\ResponseMimeType;
 use Gemini\Enums\Role;
+use Gemini\Enums\ThinkingLevel;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
 use Gemini\Testing\ClientFake;
 use ModelflowAi\Chat\Request\AIChatMessageCollection;
@@ -572,5 +574,86 @@ final class GoogleGeminiChatAdapterTest extends TestCase
                         && Role::USER === $args[2]->role;
                 },
             );
+    }
+
+    public function testHandleRequestAsksForTheLowestThinkingLevel(): void
+    {
+        $client = $this->createResponseFake();
+        $adapter = new GoogleGeminiChatAdapter($client, 'gemini-3.7-flash');
+
+        $adapter->handleRequest($this->createRequest());
+
+        $client->generativeModel('gemini-3.7-flash')
+            ->assertFunctionCalled(
+                static fn (string $method, array $args) => 'withGenerationConfig' === $method
+                    && $args[0] instanceof GenerationConfig
+                    && $args[0]->thinkingConfig instanceof ThinkingConfig
+                    && ThinkingLevel::LOW === $args[0]->thinkingConfig->thinkingLevel
+                    && false === $args[0]->thinkingConfig->includeThoughts,
+            );
+    }
+
+    public function testHandleRequestSendsTheConfiguredThinkingLevel(): void
+    {
+        $client = $this->createResponseFake();
+        $adapter = new GoogleGeminiChatAdapter($client, 'gemini-3.7-flash', ThinkingLevel::HIGH);
+
+        $adapter->handleRequest($this->createRequest());
+
+        $client->generativeModel('gemini-3.7-flash')
+            ->assertFunctionCalled(
+                static fn (string $method, array $args) => 'withGenerationConfig' === $method
+                    && $args[0] instanceof GenerationConfig
+                    && $args[0]->thinkingConfig instanceof ThinkingConfig
+                    && ThinkingLevel::HIGH === $args[0]->thinkingConfig->thinkingLevel,
+            );
+    }
+
+    public function testHandleRequestOmitsThinkingForOlderGenerations(): void
+    {
+        $client = $this->createResponseFake();
+        $adapter = new GoogleGeminiChatAdapter($client, ModelType::GEMINI_FLASH->value);
+
+        $adapter->handleRequest($this->createRequest());
+
+        $client->generativeModel(ModelType::GEMINI_FLASH->value)
+            ->assertFunctionCalled(
+                static fn (string $method, array $args) => 'withGenerationConfig' === $method
+                    && $args[0] instanceof GenerationConfig
+                    && !$args[0]->thinkingConfig instanceof ThinkingConfig,
+            );
+    }
+
+    private function createResponseFake(): ClientFake
+    {
+        return new ClientFake([
+            GenerateContentResponse::fake([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                [
+                                    'text' => 'success',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+    }
+
+    private function createRequest(): AIChatRequest
+    {
+        return new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'Hello'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+        );
     }
 }

--- a/packages/google-gemini-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\GoogleGeminiAdapter\Tests\Unit\Chat;
+
+use ModelflowAi\GoogleGeminiAdapter\Chat\ModelCapabilities;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ModelCapabilitiesTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function thinkingLevelProvider(): \Generator
+    {
+        yield 'gemini-pro' => ['gemini-pro', false];
+        yield 'gemini-1.5-flash' => ['models/gemini-1.5-flash', false];
+        yield 'gemini-2.5-flash' => ['gemini-2.5-flash', false];
+        yield 'gemini-3-pro' => ['gemini-3-pro', true];
+        yield 'gemini-3.7-flash' => ['gemini-3.7-flash', true];
+        yield 'gemini-3.7-flash qualified' => ['models/gemini-3.7-flash', true];
+        yield 'gemini-30 is a different generation' => ['gemini-30-flash', false];
+    }
+
+    #[DataProvider('thinkingLevelProvider')]
+    public function testSupportsThinkingLevel(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsThinkingLevel($model));
+    }
+}

--- a/packages/openai-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/openai-adapter/src/Chat/ModelCapabilities.php
@@ -34,13 +34,13 @@ final class ModelCapabilities
     ];
 
     /**
-     * Models documented to accept `reasoning_effort: none`. Older reasoning models know `minimal` as
-     * their lowest level instead, so they are deliberately not listed.
+     * Reasoning effort levels per model family. The GPT-5.6 family dropped `minimal`, the lowest
+     * level of the generations before it, and gained `none`.
      *
-     * @var list<string>
+     * @var array<string, list<string>>
      */
-    private const REASONING_EFFORT_NONE = [
-        'gpt-5.6',
+    private const REASONING_EFFORTS = [
+        'gpt-5.6' => ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
     ];
 
     public static function supportsSampling(string $model): bool
@@ -50,7 +50,37 @@ final class ModelCapabilities
 
     public static function supportsReasoningEffortNone(string $model): bool
     {
-        return self::matches($model, self::REASONING_EFFORT_NONE);
+        $efforts = self::reasoningEffortsFor($model);
+
+        return null !== $efforts && \in_array(ReasoningEffortEnum::NONE->value, $efforts, true);
+    }
+
+    public static function supportsReasoningEffort(string $model, ReasoningEffortEnum $effort): bool
+    {
+        $efforts = self::reasoningEffortsFor($model);
+
+        if (null === $efforts) {
+            // Nothing is documented here for this model, so only `none` is refused: it exists on
+            // the GPT-5.6 family and not on the reasoning models before it. Any other level is the
+            // caller's choice.
+            return ReasoningEffortEnum::NONE !== $effort;
+        }
+
+        return \in_array($effort->value, $efforts, true);
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private static function reasoningEffortsFor(string $model): ?array
+    {
+        foreach (self::REASONING_EFFORTS as $candidate => $efforts) {
+            if (self::matches($model, [$candidate])) {
+                return $efforts;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/packages/openai-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/openai-adapter/src/Chat/ModelCapabilities.php
@@ -43,6 +43,17 @@ final class ModelCapabilities
         'gpt-5.6' => ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
     ];
 
+    /**
+     * Families whose Chat Completions endpoint refuses function tools while reasoning is active.
+     * The default effort of `medium` is enough to trigger it, so sending nothing does not help; the
+     * API names `reasoning_effort: none` as the way out.
+     *
+     * @var list<string>
+     */
+    private const TOOLS_REQUIRE_NO_REASONING = [
+        'gpt-5.6',
+    ];
+
     public static function supportsSampling(string $model): bool
     {
         return !self::matches($model, self::SAMPLING_REMOVED);
@@ -53,6 +64,11 @@ final class ModelCapabilities
         $efforts = self::reasoningEffortsFor($model);
 
         return null !== $efforts && \in_array(ReasoningEffortEnum::NONE->value, $efforts, true);
+    }
+
+    public static function toolsRequireNoReasoning(string $model): bool
+    {
+        return self::matches($model, self::TOOLS_REQUIRE_NO_REASONING);
     }
 
     public static function supportsReasoningEffort(string $model, ReasoningEffortEnum $effort): bool

--- a/packages/openai-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/openai-adapter/src/Chat/ModelCapabilities.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\OpenaiAdapter\Chat;
+
+/**
+ * Request surface differences between the reasoning models and the rest of the OpenAI catalog.
+ *
+ * @see https://developers.openai.com/api/docs/guides/reasoning
+ */
+final class ModelCapabilities
+{
+    /**
+     * Reasoning models accept temperature only at its default of 1 and answer anything else with an
+     * unsupported_value error.
+     *
+     * @var list<string>
+     */
+    private const SAMPLING_REMOVED = [
+        'gpt-5',
+        'o1',
+        'o3',
+        'o4',
+    ];
+
+    /**
+     * Models documented to accept `reasoning_effort: none`. Older reasoning models know `minimal` as
+     * their lowest level instead, so they are deliberately not listed.
+     *
+     * @var list<string>
+     */
+    private const REASONING_EFFORT_NONE = [
+        'gpt-5.6',
+    ];
+
+    public static function supportsSampling(string $model): bool
+    {
+        return !self::matches($model, self::SAMPLING_REMOVED);
+    }
+
+    public static function supportsReasoningEffortNone(string $model): bool
+    {
+        return self::matches($model, self::REASONING_EFFORT_NONE);
+    }
+
+    /**
+     * @param list<string> $models
+     */
+    private static function matches(string $model, array $models): bool
+    {
+        foreach ($models as $candidate) {
+            // Covers both the bare model and its variants, such as "gpt-5.6-sol".
+            if ($model === $candidate || \str_starts_with($model, $candidate . '-') || \str_starts_with($model, $candidate . '.')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
+++ b/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
@@ -46,6 +46,7 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
     public function __construct(
         private ClientContract $client,
         private string $model = 'gpt-4',
+        private ?ReasoningEffortEnum $reasoningEffort = null,
     ) {
     }
 
@@ -141,8 +142,17 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
         }
 
         if ($temperature = $request->getOption('temperature')) {
-            /** @var float $temperature */
-            $parameters['temperature'] = $temperature;
+            if (ModelCapabilities::supportsSampling($this->model)) {
+                /** @var float $temperature */
+                $parameters['temperature'] = $temperature;
+            } else {
+                @\trigger_error(\sprintf('Temperature option is not supported by "%s".', $this->model), \E_USER_WARNING);
+            }
+        }
+
+        $reasoningEffort = $this->resolveReasoningEffort();
+        if ($reasoningEffort instanceof ReasoningEffortEnum) {
+            $parameters['reasoning_effort'] = $reasoningEffort->value;
         }
 
         if ($request->hasTools()) {
@@ -156,6 +166,28 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
         }
 
         return $this->create($request, $parameters);
+    }
+
+    /**
+     * Reasoning models spend output tokens on reasoning unless told otherwise, and the Chat
+     * Completions API rejects function tools while reasoning is active. Ask for no reasoning where
+     * the model supports it, unless the caller configured a level.
+     */
+    private function resolveReasoningEffort(): ?ReasoningEffortEnum
+    {
+        if (!$this->reasoningEffort instanceof ReasoningEffortEnum) {
+            return ModelCapabilities::supportsReasoningEffortNone($this->model)
+                ? ReasoningEffortEnum::NONE
+                : null;
+        }
+
+        if (ReasoningEffortEnum::NONE === $this->reasoningEffort && !ModelCapabilities::supportsReasoningEffortNone($this->model)) {
+            @\trigger_error(\sprintf('Reasoning effort "none" is not supported by "%s".', $this->model), \E_USER_WARNING);
+
+            return null;
+        }
+
+        return $this->reasoningEffort;
     }
 
     /**

--- a/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
+++ b/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
@@ -181,8 +181,8 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
                 : null;
         }
 
-        if (ReasoningEffortEnum::NONE === $this->reasoningEffort && !ModelCapabilities::supportsReasoningEffortNone($this->model)) {
-            @\trigger_error(\sprintf('Reasoning effort "none" is not supported by "%s".', $this->model), \E_USER_WARNING);
+        if (!ModelCapabilities::supportsReasoningEffort($this->model, $this->reasoningEffort)) {
+            @\trigger_error(\sprintf('Reasoning effort "%s" is not supported by "%s".', $this->reasoningEffort->value, $this->model), \E_USER_WARNING);
 
             return null;
         }

--- a/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
+++ b/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
@@ -150,7 +150,7 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
             }
         }
 
-        $reasoningEffort = $this->resolveReasoningEffort();
+        $reasoningEffort = $this->resolveReasoningEffort($request);
         if ($reasoningEffort instanceof ReasoningEffortEnum) {
             $parameters['reasoning_effort'] = $reasoningEffort->value;
         }
@@ -173,8 +173,16 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
      * Completions API rejects function tools while reasoning is active. Ask for no reasoning where
      * the model supports it, unless the caller configured a level.
      */
-    private function resolveReasoningEffort(): ?ReasoningEffortEnum
+    private function resolveReasoningEffort(AIChatRequest $request): ?ReasoningEffortEnum
     {
+        if ($request->hasTools() && ModelCapabilities::toolsRequireNoReasoning($this->model)) {
+            if ($this->reasoningEffort instanceof ReasoningEffortEnum && ReasoningEffortEnum::NONE !== $this->reasoningEffort) {
+                @\trigger_error(\sprintf('Reasoning effort "%s" cannot be combined with tools for "%s", falling back to "none".', $this->reasoningEffort->value, $this->model), \E_USER_WARNING);
+            }
+
+            return ReasoningEffortEnum::NONE;
+        }
+
         if (!$this->reasoningEffort instanceof ReasoningEffortEnum) {
             return ModelCapabilities::supportsReasoningEffortNone($this->model)
                 ? ReasoningEffortEnum::NONE

--- a/packages/openai-adapter/src/Chat/OpenaiChatAdapterFactory.php
+++ b/packages/openai-adapter/src/Chat/OpenaiChatAdapterFactory.php
@@ -21,16 +21,24 @@ final readonly class OpenaiChatAdapterFactory implements AIChatAdapterFactoryInt
 {
     public function __construct(
         private ClientContract $client,
+        private ?ReasoningEffortEnum $reasoningEffort = null,
     ) {
     }
 
     public function createChatAdapter(array $options): AIChatAdapterInterface
     {
-        $model = \str_replace('gpt', 'gpt-', (string) $options['model']);
+        $model = (string) $options['model'];
+
+        // Adapter keys have historically been written without the dash, such as "gpt4o" for the
+        // "gpt-4o" model. Newer model ids already carry it and must not get a second one.
+        if (\str_starts_with($model, 'gpt') && !\str_starts_with($model, 'gpt-')) {
+            $model = 'gpt-' . \substr($model, 3);
+        }
 
         return new OpenaiChatAdapter(
             $this->client,
             $model,
+            $this->reasoningEffort,
         );
     }
 }

--- a/packages/openai-adapter/src/Chat/ReasoningEffortEnum.php
+++ b/packages/openai-adapter/src/Chat/ReasoningEffortEnum.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\OpenaiAdapter\Chat;
+
+/**
+ * @see https://developers.openai.com/api/docs/guides/reasoning
+ */
+enum ReasoningEffortEnum: string
+{
+    case NONE = 'none';
+    case MINIMAL = 'minimal';
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+    case HIGH = 'high';
+    case XHIGH = 'xhigh';
+    case MAX = 'max';
+}

--- a/packages/openai-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ModelflowAi\OpenaiAdapter\Tests\Unit\Chat;
 
 use ModelflowAi\OpenaiAdapter\Chat\ModelCapabilities;
+use ModelflowAi\OpenaiAdapter\Chat\ReasoningEffortEnum;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -57,5 +58,25 @@ final class ModelCapabilitiesTest extends TestCase
     public function testSupportsReasoningEffortNone(string $model, bool $expected): void
     {
         $this->assertSame($expected, ModelCapabilities::supportsReasoningEffortNone($model));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: ReasoningEffortEnum, 2: bool}>
+     */
+    public static function reasoningEffortProvider(): \Generator
+    {
+        yield 'gpt-5.6 knows none' => ['gpt-5.6-sol', ReasoningEffortEnum::NONE, true];
+        yield 'gpt-5.6 dropped minimal' => ['gpt-5.6-sol', ReasoningEffortEnum::MINIMAL, false];
+        yield 'gpt-5.6 knows xhigh' => ['gpt-5.6-terra', ReasoningEffortEnum::XHIGH, true];
+        yield 'gpt-5.6 knows max' => ['gpt-5.6-luna', ReasoningEffortEnum::MAX, true];
+        yield 'unknown model refuses none' => ['o3', ReasoningEffortEnum::NONE, false];
+        yield 'unknown model keeps minimal' => ['o3', ReasoningEffortEnum::MINIMAL, true];
+        yield 'unknown model keeps high' => ['o3', ReasoningEffortEnum::HIGH, true];
+    }
+
+    #[DataProvider('reasoningEffortProvider')]
+    public function testSupportsReasoningEffort(string $model, ReasoningEffortEnum $effort, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsReasoningEffort($model, $effort));
     }
 }

--- a/packages/openai-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\OpenaiAdapter\Tests\Unit\Chat;
+
+use ModelflowAi\OpenaiAdapter\Chat\ModelCapabilities;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ModelCapabilitiesTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function samplingProvider(): \Generator
+    {
+        yield 'gpt-4' => ['gpt-4', true];
+        yield 'gpt-4o' => ['gpt-4o', true];
+        yield 'gpt-5' => ['gpt-5', false];
+        yield 'gpt-5.6-sol' => ['gpt-5.6-sol', false];
+        yield 'o1' => ['o1', false];
+        yield 'o3-mini' => ['o3-mini', false];
+    }
+
+    #[DataProvider('samplingProvider')]
+    public function testSupportsSampling(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsSampling($model));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function reasoningEffortNoneProvider(): \Generator
+    {
+        yield 'gpt-4' => ['gpt-4', false];
+        yield 'gpt-5.4' => ['gpt-5.4', false];
+        yield 'gpt-5.5' => ['gpt-5.5', false];
+        yield 'gpt-5.6' => ['gpt-5.6', true];
+        yield 'gpt-5.6-sol' => ['gpt-5.6-sol', true];
+        yield 'gpt-5.6-terra' => ['gpt-5.6-terra', true];
+        yield 'gpt-5.6-luna' => ['gpt-5.6-luna', true];
+        yield 'o3' => ['o3', false];
+    }
+
+    #[DataProvider('reasoningEffortNoneProvider')]
+    public function testSupportsReasoningEffortNone(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsReasoningEffortNone($model));
+    }
+}

--- a/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterFactoryTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterFactoryTest.php
@@ -13,10 +13,21 @@ declare(strict_types=1);
 
 namespace ModelflowAi\OpenaiAdapter\Tests\Unit\Chat;
 
+use ModelflowAi\Chat\Request\AIChatMessageCollection;
+use ModelflowAi\Chat\Request\AIChatRequest;
+use ModelflowAi\Chat\Request\Message\AIChatMessage;
+use ModelflowAi\Chat\Request\Message\AIChatMessageRoleEnum;
+use ModelflowAi\DecisionTree\Criteria\CriteriaCollection;
 use ModelflowAi\OpenaiAdapter\Chat\OpenaiChatAdapter;
 use ModelflowAi\OpenaiAdapter\Chat\OpenaiChatAdapterFactory;
 use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\Resources\ChatContract;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Testing\Responses\Fixtures\Chat\CreateResponseFixture;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 class OpenaiChatAdapterFactoryTest extends TestCase
@@ -36,5 +47,61 @@ class OpenaiChatAdapterFactoryTest extends TestCase
             'priority' => 0,
         ]);
         $this->assertInstanceOf(OpenaiChatAdapter::class, $adapter);
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: string}>
+     */
+    public static function modelProvider(): \Generator
+    {
+        yield 'legacy key without dash' => ['gpt4o', 'gpt-4o'];
+        yield 'legacy key with version' => ['gpt5.5', 'gpt-5.5'];
+        yield 'model id already dashed' => ['gpt-5.6-sol', 'gpt-5.6-sol'];
+        yield 'non gpt model' => ['o3-mini', 'o3-mini'];
+    }
+
+    #[DataProvider('modelProvider')]
+    public function testCreateChatAdapterNormalizesTheModelId(string $configured, string $expected): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $attributes = CreateResponseFixture::ATTRIBUTES;
+        $attributes['system_fingerprint'] = '123-123-123';
+
+        $chat->create(Argument::withEntry('model', $expected))
+            ->willReturn(CreateResponse::from(
+                $attributes,
+                MetaInformation::from([
+                    'x-request-id' => ['123'],
+                    'openai-model' => [$expected],
+                    'openai-organization' => ['org'],
+                    'openai-version' => ['2021-10-10'],
+                    'openai-processing-ms' => ['123'],
+                    'x-ratelimit-limit-requests' => ['123'],
+                    'x-ratelimit-limit-tokens' => ['123'],
+                    'x-ratelimit-remaining-requests' => ['123'],
+                    'x-ratelimit-remaining-tokens' => ['123'],
+                    'x-ratelimit-reset-requests' => ['123'],
+                    'x-ratelimit-reset-tokens' => ['123'],
+                ]),
+            ))
+            ->shouldBeCalled();
+
+        $adapter = (new OpenaiChatAdapterFactory($client->reveal()))->createChatAdapter([
+            'model' => $configured,
+        ]);
+
+        $adapter->handleRequest(new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'User message'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+        ));
     }
 }

--- a/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
@@ -670,7 +670,9 @@ final class OpenaiChatAdapterTest extends TestCase
         ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
 
         $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol');
-        @$adapter->handleRequest($this->createRequest(['temperature' => 0.5]));
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest(['temperature' => 0.5])));
+
+        $this->assertSame(['Temperature option is not supported by "gpt-5.6-sol".'], $warnings);
     }
 
     public function testHandleRequestSendsTheConfiguredReasoningEffort(): void
@@ -723,7 +725,75 @@ final class OpenaiChatAdapterTest extends TestCase
         ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
 
         $adapter = new OpenaiChatAdapter($client->reveal(), 'o3', ReasoningEffortEnum::NONE);
-        @$adapter->handleRequest($this->createRequest());
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
+
+        $this->assertSame(['Reasoning effort "none" is not supported by "o3".'], $warnings);
+    }
+
+    public function testHandleRequestWarnsWhenMinimalIsUnsupported(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'gpt-5.6-sol',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol', ReasoningEffortEnum::MINIMAL);
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
+
+        $this->assertSame(['Reasoning effort "minimal" is not supported by "gpt-5.6-sol".'], $warnings);
+    }
+
+    public function testHandleRequestPassesAnEffortThroughForUnknownModels(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'o3',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+            'reasoning_effort' => 'high',
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'o3', ReasoningEffortEnum::HIGH);
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
+
+        $this->assertSame([], $warnings);
+    }
+
+    /**
+     * The adapter suppresses its warnings with @, which PHPUnit honours, so they have to be read
+     * from an error handler instead.
+     *
+     * @return list<string>
+     */
+    private function captureWarnings(callable $callback): array
+    {
+        $warnings = [];
+
+        \set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+            if (\E_USER_WARNING === $severity) {
+                $warnings[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            $callback();
+        } finally {
+            \restore_error_handler();
+        }
+
+        return $warnings;
     }
 
     private function createFixtureResponse(): CreateResponse

--- a/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
@@ -35,6 +35,7 @@ use ModelflowAi\Chat\ToolInfo\ToolInfoBuilder;
 use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use ModelflowAi\DecisionTree\Criteria\CriteriaCollection;
 use ModelflowAi\OpenaiAdapter\Chat\OpenaiChatAdapter;
+use ModelflowAi\OpenaiAdapter\Chat\ReasoningEffortEnum;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\Resources\ChatContract;
 use OpenAI\Responses\Chat\CreateResponse;
@@ -634,5 +635,134 @@ final class OpenaiChatAdapterTest extends TestCase
     public function toolMethod(string $required, string $optional = ''): string
     {
         return $required . $optional;
+    }
+
+    public function testHandleRequestAsksForNoReasoningOnReasoningModels(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'gpt-5.6-sol',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+            'reasoning_effort' => 'none',
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol');
+        $adapter->handleRequest($this->createRequest());
+    }
+
+    public function testHandleRequestOmitsTemperatureOnReasoningModels(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'gpt-5.6-sol',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+            'reasoning_effort' => 'none',
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol');
+        @$adapter->handleRequest($this->createRequest(['temperature' => 0.5]));
+    }
+
+    public function testHandleRequestSendsTheConfiguredReasoningEffort(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'gpt-5.6-sol',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+            'reasoning_effort' => 'high',
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol', ReasoningEffortEnum::HIGH);
+        $adapter->handleRequest($this->createRequest());
+    }
+
+    public function testHandleRequestOmitsReasoningEffortOnModelsWithoutSupport(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'gpt-4',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+            'temperature' => 0.5,
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal());
+        $adapter->handleRequest($this->createRequest(['temperature' => 0.5]));
+    }
+
+    public function testHandleRequestWarnsWhenNoneIsUnsupported(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'o3',
+            'messages' => [
+                ['role' => 'user', 'content' => 'User message'],
+            ],
+        ])->willReturn($this->createFixtureResponse())->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'o3', ReasoningEffortEnum::NONE);
+        @$adapter->handleRequest($this->createRequest());
+    }
+
+    private function createFixtureResponse(): CreateResponse
+    {
+        $attributes = CreateResponseFixture::ATTRIBUTES;
+        $attributes['system_fingerprint'] = '123-123-123';
+
+        return CreateResponse::from(
+            $attributes,
+            MetaInformation::from([
+                'x-request-id' => ['123'],
+                'openai-model' => ['gpt-4'],
+                'openai-organization' => ['org'],
+                'openai-version' => ['2021-10-10'],
+                'openai-processing-ms' => ['123'],
+                'x-ratelimit-limit-requests' => ['123'],
+                'x-ratelimit-limit-tokens' => ['123'],
+                'x-ratelimit-remaining-requests' => ['123'],
+                'x-ratelimit-remaining-tokens' => ['123'],
+                'x-ratelimit-reset-requests' => ['123'],
+                'x-ratelimit-reset-tokens' => ['123'],
+            ]),
+        );
+    }
+
+    /**
+     * @param array{seed?: int, temperature?: float} $options
+     */
+    private function createRequest(array $options = []): AIChatRequest
+    {
+        return new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'User message'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            $options,
+            static fn () => null,
+        );
     }
 }

--- a/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/OpenaiChatAdapterTest.php
@@ -44,6 +44,7 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\ClientFake;
 use OpenAI\Testing\Responses\Fixtures\Chat\CreateResponseFixture;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 final class OpenaiChatAdapterTest extends TestCase
@@ -767,6 +768,73 @@ final class OpenaiChatAdapterTest extends TestCase
         $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
 
         $this->assertSame([], $warnings);
+    }
+
+    public function testHandleRequestAsksForNoReasoningWhenToolsAreSent(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create(Argument::withEntry('reasoning_effort', 'none'))
+            ->willReturn($this->createFixtureResponse())
+            ->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol');
+        $adapter->handleRequest($this->createToolRequest());
+    }
+
+    public function testHandleRequestDropsAConfiguredEffortWhenToolsAreSent(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create(Argument::withEntry('reasoning_effort', 'none'))
+            ->willReturn($this->createFixtureResponse())
+            ->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'gpt-5.6-sol', ReasoningEffortEnum::HIGH);
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createToolRequest()));
+
+        $this->assertSame(
+            ['Reasoning effort "high" cannot be combined with tools for "gpt-5.6-sol", falling back to "none".'],
+            $warnings,
+        );
+    }
+
+    public function testHandleRequestKeepsTheEffortWithToolsOnOtherModels(): void
+    {
+        $chat = $this->prophesize(ChatContract::class);
+        $client = $this->prophesize(ClientContract::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create(Argument::withEntry('reasoning_effort', 'high'))
+            ->willReturn($this->createFixtureResponse())
+            ->shouldBeCalled();
+
+        $adapter = new OpenaiChatAdapter($client->reveal(), 'o3', ReasoningEffortEnum::HIGH);
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createToolRequest()));
+
+        $this->assertSame([], $warnings);
+    }
+
+    private function createToolRequest(): AIChatRequest
+    {
+        return new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'User message'),
+            ),
+            new CriteriaCollection(),
+            [
+                'test' => [$this, 'toolMethod'],
+            ],
+            [
+                ToolInfoBuilder::buildToolInfo($this, 'toolMethod', 'test'),
+            ],
+            [],
+            static fn () => null,
+        );
     }
 
     /**


### PR DESCRIPTION
Follow up to #158, which did the same for Anthropic. OpenAI and Google reason by default on their current models and bill every thought as an output token, and neither adapter said anything about it.

## OpenAI

`gpt-5.6` defaults to `reasoning_effort: medium`. Besides the cost, the Chat Completions API — the endpoint this adapter uses — refuses function tools while reasoning is active:

> Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

So a tool call against the 5.6 family fails today. The adapter now sends `reasoning_effort: none` for the models documented to accept it, which is the 5.6 family; older reasoning models know `minimal` as their lowest level and are deliberately not listed.

Reasoning models also accept `temperature` only at its default of 1 and answer anything else with `unsupported_value`, so the temperature option is dropped for them with a warning, in the same style as the existing unsupported `seed` option.

`OpenaiChatAdapterFactory` also stops mangling model ids: `str_replace('gpt', 'gpt-', …)` turned `gpt-5.6-sol` into `gpt--5.6-sol`. The dash is now only inserted when it is actually missing, so the legacy adapter keys (`gpt4o`, `gpt5.5`) keep resolving as before.

## Google

Gemini 3 defaults to `thinkingLevel: medium` and, unlike the other providers, cannot be switched off: `minimal` is rejected on 3.7 Flash and `low` is the lowest level every Gemini 3 model accepts. The adapter now asks for `low` on Gemini 3 models and leaves older generations alone, since those expect a `thinkingBudget` in tokens instead.

## Configuration

Both defaults are overridable — `ReasoningEffortEnum` on `OpenaiChatAdapter`/`OpenaiChatAdapterFactory`, `ThinkingLevel` on `GoogleGeminiChatAdapter`/`GoogleGeminiChatAdapterFactory` — so a caller that wants the provider default back can ask for it explicitly.

## Verification

`composer test` and `composer lint` are green in both packages: 50 tests in the OpenAI adapter, 36 in the Google adapter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable thinking levels for supported Gemini models, with sensible defaults and compatibility handling for older models.
  - Added configurable reasoning effort levels for OpenAI models, including automatic support checks and defaults.
- **Bug Fixes**
  - Improved OpenAI model ID normalization to prevent malformed identifiers.
  - Requests now omit unsupported parameters and provide warnings when incompatible settings are selected.
- **Tests**
  - Added coverage for model capabilities, configuration behavior, and model ID normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->