### PR TITLE
Support Mistral Medium 3.5 and the models Mistral only hosts

### DIFF
--- a/packages/mistral-adapter/src/Chat/MistralChatAdapter.php
+++ b/packages/mistral-adapter/src/Chat/MistralChatAdapter.php
@@ -43,6 +43,7 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
     public function __construct(
         private ClientInterface $client,
         private string $model = Model::TINY->value,
+        private ?ReasoningEffortEnum $reasoningEffort = null,
     ) {
     }
 
@@ -107,7 +108,7 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
             'messages' => $messages,
         ];
 
-        if (Model::from($this->model)->jsonSupported()) {
+        if (Model::jsonSupportedBy($this->model)) {
             $responseFormat = $request->getResponseFormat();
 
             if ($responseFormat instanceof JsonSchemaResponseFormat) {
@@ -136,6 +137,11 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
 
         if ($temperature = $request->getOption('temperature')) {
             $parameters['temperature'] = $temperature;
+        }
+
+        $reasoningEffort = $this->resolveReasoningEffort();
+        if ($reasoningEffort instanceof ReasoningEffortEnum) {
+            $parameters['reasoning_effort'] = $reasoningEffort->value;
         }
 
         if ($request instanceof AIChatStreamedRequest) {
@@ -171,6 +177,7 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
      *         },
      *     }>,
      *     tool_choice?: string,
+     *     reasoning_effort?: string,
      * } $parameters
      */
     private function create(AIChatRequest $request, array $parameters): AIChatResponse
@@ -242,6 +249,7 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
      *         },
      *     }>,
      *     tool_choice?: string,
+     *     reasoning_effort?: string,
      * } $parameters
      */
     private function createStreamed(AIChatStreamedRequest $request, array $parameters): AIChatResponse
@@ -317,6 +325,23 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
     }
 
     /**
+     * Reasoning is off unless a request asks for it, but saying so explicitly keeps a changed
+     * default from silently billing thinking tokens.
+     */
+    private function resolveReasoningEffort(): ?ReasoningEffortEnum
+    {
+        if (!ModelCapabilities::supportsReasoningEffort($this->model)) {
+            if ($this->reasoningEffort instanceof ReasoningEffortEnum) {
+                @\trigger_error(\sprintf('Reasoning effort is not supported by "%s".', $this->model), \E_USER_WARNING);
+            }
+
+            return null;
+        }
+
+        return $this->reasoningEffort ?? ReasoningEffortEnum::NONE;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function decodeArguments(string $arguments): array
@@ -330,11 +355,11 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
     public function supportsResponseFormat(ResponseFormatInterface $responseFormat): bool
     {
         if ($responseFormat instanceof JsonResponseFormat) {
-            return Model::from($this->model)->jsonSupported();
+            return Model::jsonSupportedBy($this->model);
         }
 
         if ($responseFormat instanceof JsonSchemaResponseFormat) {
-            return Model::from($this->model)->jsonSupported();
+            return Model::jsonSupportedBy($this->model);
         }
 
         return false;
@@ -343,6 +368,6 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
     public function supports(object $request): bool
     {
         return $request instanceof AIChatRequest
-            && (!$request->hasTools() || Model::from($this->model)->toolsSupported());
+            && (!$request->hasTools() || Model::toolsSupportedBy($this->model));
     }
 }

--- a/packages/mistral-adapter/src/Chat/MistralChatAdapterFactory.php
+++ b/packages/mistral-adapter/src/Chat/MistralChatAdapterFactory.php
@@ -21,6 +21,7 @@ final readonly class MistralChatAdapterFactory implements AIChatAdapterFactoryIn
 {
     public function __construct(
         private ClientInterface $client,
+        private ?ReasoningEffortEnum $reasoningEffort = null,
     ) {
     }
 
@@ -29,6 +30,7 @@ final readonly class MistralChatAdapterFactory implements AIChatAdapterFactoryIn
         return new MistralChatAdapter(
             $this->client,
             $options['model'],
+            $this->reasoningEffort,
         );
     }
 }

--- a/packages/mistral-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/mistral-adapter/src/Chat/ModelCapabilities.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\MistralAdapter\Chat;
+
+/**
+ * Request surface differences between the hybrid models, which answer with a thinking chunk when
+ * asked to, and the rest of the Mistral catalog.
+ *
+ * @see https://docs.mistral.ai/capabilities/reasoning
+ */
+final class ModelCapabilities
+{
+    /**
+     * The hybrid models are the only ones that accept `reasoning_effort`; the others reject it.
+     * Listed one by one on purpose: the snapshots released before a family became hybrid share its
+     * name, so matching the family as a prefix would send the parameter to models that refuse it.
+     *
+     * @var list<string>
+     */
+    private const REASONING_EFFORT_SUPPORTED = [
+        'mistral-small-latest',
+        'mistral-medium-latest',
+        'mistral-medium-3-5',
+    ];
+
+    public static function supportsReasoningEffort(string $model): bool
+    {
+        return \in_array($model, self::REASONING_EFFORT_SUPPORTED, true);
+    }
+}

--- a/packages/mistral-adapter/src/Chat/ReasoningEffortEnum.php
+++ b/packages/mistral-adapter/src/Chat/ReasoningEffortEnum.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\MistralAdapter\Chat;
+
+/**
+ * The two levels the hybrid models accept. Unlike the graded scales of other providers this is a
+ * switch: `high` returns a thinking chunk before the answer, `none` leaves it out.
+ *
+ * @see https://docs.mistral.ai/capabilities/reasoning
+ */
+enum ReasoningEffortEnum: string
+{
+    case NONE = 'none';
+    case HIGH = 'high';
+}

--- a/packages/mistral-adapter/tests/Unit/Chat/MistralChatAdapterTest.php
+++ b/packages/mistral-adapter/tests/Unit/Chat/MistralChatAdapterTest.php
@@ -38,6 +38,7 @@ use ModelflowAi\Mistral\Resources\ChatInterface;
 use ModelflowAi\Mistral\Responses\Chat\CreateResponse;
 use ModelflowAi\Mistral\Responses\Chat\CreateStreamedResponse;
 use ModelflowAi\MistralAdapter\Chat\MistralChatAdapter;
+use ModelflowAi\MistralAdapter\Chat\ReasoningEffortEnum;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -811,6 +812,190 @@ final class MistralChatAdapterTest extends TestCase
             'type' => 'object',
             'properties' => [],
         ])));
+    }
+
+    public function testHandleRequestAsksAHybridModelNotToThink(): void
+    {
+        $chat = $this->prophesize(ChatInterface::class);
+        $client = $this->prophesize(ClientInterface::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => Model::MEDIUM->value,
+            'messages' => [
+                ['role' => 'user', 'content' => 'some text'],
+            ],
+            'reasoning_effort' => 'none',
+        ])->willReturn($this->createResponse(Model::MEDIUM->value));
+
+        $adapter = new MistralChatAdapter($client->reveal(), Model::MEDIUM->value);
+        $result = $adapter->handleRequest($this->createRequest());
+
+        $this->assertSame('Lorem Ipsum', $result->getMessage()->content);
+    }
+
+    public function testHandleRequestSendsTheConfiguredReasoningEffort(): void
+    {
+        $chat = $this->prophesize(ChatInterface::class);
+        $client = $this->prophesize(ClientInterface::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => Model::SMALL->value,
+            'messages' => [
+                ['role' => 'user', 'content' => 'some text'],
+            ],
+            'reasoning_effort' => 'high',
+        ])->willReturn($this->createResponse(Model::SMALL->value));
+
+        $adapter = new MistralChatAdapter($client->reveal(), Model::SMALL->value, ReasoningEffortEnum::HIGH);
+        $result = $adapter->handleRequest($this->createRequest());
+
+        $this->assertSame('Lorem Ipsum', $result->getMessage()->content);
+    }
+
+    public function testHandleRequestOmitsTheReasoningEffortOnAModelWithoutIt(): void
+    {
+        $chat = $this->prophesize(ChatInterface::class);
+        $client = $this->prophesize(ClientInterface::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => Model::LARGE->value,
+            'messages' => [
+                ['role' => 'user', 'content' => 'some text'],
+            ],
+        ])->willReturn($this->createResponse(Model::LARGE->value));
+
+        $adapter = new MistralChatAdapter($client->reveal(), Model::LARGE->value, ReasoningEffortEnum::HIGH);
+
+        $warnings = $this->captureWarnings(fn () => $adapter->handleRequest($this->createRequest()));
+
+        $this->assertSame(['Reasoning effort is not supported by "mistral-large-latest".'], $warnings);
+    }
+
+    public function testHandleRequestKeepsTheResponseFormatForAModelOutsideTheCatalog(): void
+    {
+        $chat = $this->prophesize(ChatInterface::class);
+        $client = $this->prophesize(ClientInterface::class);
+        $client->chat()->willReturn($chat->reveal());
+
+        $chat->create([
+            'model' => 'zai-glm-5-2',
+            'messages' => [
+                ['role' => 'user', 'content' => 'some text'],
+            ],
+            'response_format' => ['type' => 'json_object'],
+        ])->willReturn($this->createResponse('zai-glm-5-2'));
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'some text'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+            [],
+            new JsonResponseFormat(),
+        );
+
+        $adapter = new MistralChatAdapter($client->reveal(), 'zai-glm-5-2');
+        $result = $adapter->handleRequest($request);
+
+        $this->assertSame('Lorem Ipsum', $result->getMessage()->content);
+    }
+
+    public function testSupportsAModelOutsideTheCatalogWithTools(): void
+    {
+        $client = $this->prophesize(ClientInterface::class);
+
+        $adapter = new MistralChatAdapter($client->reveal(), 'zai-glm-5-2');
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'User message'),
+            ),
+            new CriteriaCollection(),
+            [
+                'test' => [$this, 'toolMethod'],
+            ],
+            [
+                ToolInfoBuilder::buildToolInfo($this, 'toolMethod', 'test'),
+            ],
+            [],
+            static fn () => null,
+        );
+
+        $this->assertTrue($adapter->supports($request));
+        $this->assertTrue($adapter->supportsResponseFormat(new JsonResponseFormat()));
+    }
+
+    private function createRequest(): AIChatRequest
+    {
+        return new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'some text'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+        );
+    }
+
+    private function createResponse(string $model): CreateResponse
+    {
+        return CreateResponse::from([
+            'id' => 'cmpl-e5cc70bb28c444948073e77776eb30ef',
+            'object' => 'chat.completion',
+            'created' => 1_702_256_327,
+            'model' => $model,
+            'choices' => [
+                [
+                    'index' => 1,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Lorem Ipsum',
+                    ],
+                    'finish_reason' => 'testFinishReason',
+                ],
+            ],
+            'usage' => [
+                'prompt_tokens' => 312,
+                'completion_tokens' => 324,
+                'total_tokens' => 636,
+            ],
+        ], MetaInformation::from([]));
+    }
+
+    /**
+     * The adapter suppresses its warnings with @, which PHPUnit honours, so they have to be read
+     * from an error handler instead.
+     *
+     * @return list<string>
+     */
+    private function captureWarnings(callable $callback): array
+    {
+        $warnings = [];
+
+        \set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+            if (\E_USER_WARNING === $severity) {
+                $warnings[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            $callback();
+        } finally {
+            \restore_error_handler();
+        }
+
+        return $warnings;
     }
 
     /**

--- a/packages/mistral-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/mistral-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\MistralAdapter\Tests\Unit\Chat;
+
+use ModelflowAi\MistralAdapter\Chat\ModelCapabilities;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ModelCapabilitiesTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function reasoningEffortProvider(): \Generator
+    {
+        yield 'mistral-small-latest' => ['mistral-small-latest', true];
+        yield 'mistral-medium-latest' => ['mistral-medium-latest', true];
+        yield 'mistral-medium-3-5' => ['mistral-medium-3-5', true];
+        yield 'mistral-large-latest' => ['mistral-large-latest', false];
+        yield 'mistral-tiny' => ['mistral-tiny', false];
+        yield 'a snapshot from before the family became hybrid' => ['mistral-medium-2508', false];
+        yield 'zai-glm-5-2' => ['zai-glm-5-2', false];
+    }
+
+    #[DataProvider('reasoningEffortProvider')]
+    public function testSupportsReasoningEffort(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsReasoningEffort($model));
+    }
+}

--- a/packages/mistral/src/Model.php
+++ b/packages/mistral/src/Model.php
@@ -27,11 +27,26 @@ enum Model: string
 
     public function jsonSupported(): bool
     {
-        return \in_array($this, [self::SMALL, self::LARGE], true);
+        return \in_array($this, [self::SMALL, self::MEDIUM, self::LARGE], true);
     }
 
     public function toolsSupported(): bool
     {
         return \in_array($this, [self::SMALL, self::MEDIUM, self::LARGE, self::NEMO, self::PIXTRAL_LARGE], true);
+    }
+
+    /**
+     * Mistral adds models faster than this list follows them, and the models it merely hosts, such
+     * as `zai-glm-5-2`, will never be part of it. An id that is unknown here is therefore treated as
+     * a current model, which supports both response formats and tools.
+     */
+    public static function jsonSupportedBy(string $model): bool
+    {
+        return self::tryFrom($model)?->jsonSupported() ?? true;
+    }
+
+    public static function toolsSupportedBy(string $model): bool
+    {
+        return self::tryFrom($model)?->toolsSupported() ?? true;
     }
 }

--- a/packages/mistral/src/Resources/Chat.php
+++ b/packages/mistral/src/Resources/Chat.php
@@ -111,7 +111,7 @@ final readonly class Chat implements ChatInterface
             }
         }
 
-        if (!Model::from($parameters['model'])->toolsSupported()) {
+        if (!Model::toolsSupportedBy($parameters['model'])) {
             Assert::keyNotExists($parameters, 'tools');
             Assert::keyNotExists($parameters, 'tool_choice');
         } else {
@@ -158,10 +158,14 @@ final readonly class Chat implements ChatInterface
         if (isset($parameters['random_seed'])) {
             Assert::integer($parameters['random_seed']);
         }
+        if (isset($parameters['reasoning_effort'])) {
+            Assert::string($parameters['reasoning_effort']);
+            Assert::inArray($parameters['reasoning_effort'], ['none', 'high']);
+        }
 
-        if (!Model::from($parameters['model'])->jsonSupported()) {
+        if (!Model::jsonSupportedBy($parameters['model'])) {
             Assert::keyNotExists($parameters, 'response_format');
-        } elseif (Model::from($parameters['model'])->jsonSupported() && isset($parameters['response_format'])) {
+        } elseif (isset($parameters['response_format'])) {
             Assert::keyExists($parameters, 'response_format');
             Assert::isArray($parameters['response_format']);
             Assert::keyExists($parameters['response_format'], 'type');

--- a/packages/mistral/src/Responses/Chat/ContentChunks.php
+++ b/packages/mistral/src/Responses/Chat/ContentChunks.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Chat;
+
+/**
+ * A model that thinks answers with a list of chunks instead of a string: `thinking` carries the
+ * trace, `text` the answer. Streaming mixes both, and the chunk where the trace ends carries the
+ * first piece of the answer with it.
+ *
+ * Only the answer survives here. Carrying the trace any further would mean modelling it all the way
+ * through the chat response, which is a question for the chat package rather than this client.
+ *
+ * @see https://docs.mistral.ai/capabilities/reasoning
+ */
+final class ContentChunks
+{
+    /**
+     * @param string|list<string|array{type?: string, text?: string, thinking?: mixed}>|null $content
+     */
+    public static function toText(string|array|null $content): ?string
+    {
+        if (!\is_array($content)) {
+            return $content;
+        }
+
+        $text = '';
+        foreach ($content as $chunk) {
+            if (\is_string($chunk)) {
+                $text .= $chunk;
+
+                continue;
+            }
+
+            if ('text' === ($chunk['type'] ?? null)) {
+                $text .= $chunk['text'] ?? '';
+            }
+        }
+
+        return $text;
+    }
+}

--- a/packages/mistral/src/Responses/Chat/CreateResponseMessage.php
+++ b/packages/mistral/src/Responses/Chat/CreateResponseMessage.php
@@ -28,7 +28,7 @@ final readonly class CreateResponseMessage
     /**
      * @param array{
      *     role: string,
-     *     content: ?string,
+     *     content: string|list<string|array{type?: string, text?: string, thinking?: mixed}>|null,
      *     tool_calls?: array<array{
      *         id: string,
      *         type: string,
@@ -48,7 +48,7 @@ final readonly class CreateResponseMessage
 
         return new self(
             $attributes['role'],
-            $attributes['content'] ?? null,
+            ContentChunks::toText($attributes['content'] ?? null),
             $toolCalls,
         );
     }

--- a/packages/mistral/src/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/packages/mistral/src/Responses/Chat/CreateStreamedResponseDelta.php
@@ -28,7 +28,7 @@ final readonly class CreateStreamedResponseDelta
     /**
      * @param array{
      *     role?: string|null,
-     *     content?: string|null,
+     *     content?: string|list<string|array{type?: string, text?: string, thinking?: mixed}>|null,
      *     tool_calls?: array<array{
      *         id?: string,
      *         type?: string,
@@ -48,7 +48,7 @@ final readonly class CreateStreamedResponseDelta
 
         return new self(
             $attributes['role'] ?? null,
-            $attributes['content'] ?? null,
+            ContentChunks::toText($attributes['content'] ?? null),
             $toolCalls,
         );
     }

--- a/packages/mistral/tests/Unit/ModelTest.php
+++ b/packages/mistral/tests/Unit/ModelTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Tests\Unit;
+
+use ModelflowAi\Mistral\Model;
+use PHPUnit\Framework\TestCase;
+
+final class ModelTest extends TestCase
+{
+    public function testJsonSupported(): void
+    {
+        $this->assertTrue(Model::SMALL->jsonSupported());
+        $this->assertTrue(Model::MEDIUM->jsonSupported());
+        $this->assertTrue(Model::LARGE->jsonSupported());
+        $this->assertFalse(Model::TINY->jsonSupported());
+    }
+
+    public function testToolsSupported(): void
+    {
+        $this->assertTrue(Model::LARGE->toolsSupported());
+        $this->assertFalse(Model::TINY->toolsSupported());
+    }
+
+    public function testSupportedByForKnownModel(): void
+    {
+        $this->assertTrue(Model::jsonSupportedBy(Model::LARGE->value));
+        $this->assertFalse(Model::jsonSupportedBy(Model::TINY->value));
+        $this->assertTrue(Model::toolsSupportedBy(Model::LARGE->value));
+        $this->assertFalse(Model::toolsSupportedBy(Model::TINY->value));
+    }
+
+    public function testSupportedByForModelOutsideTheCatalog(): void
+    {
+        $this->assertTrue(Model::jsonSupportedBy('zai-glm-5-2'));
+        $this->assertTrue(Model::toolsSupportedBy('zai-glm-5-2'));
+    }
+}

--- a/packages/mistral/tests/Unit/Resources/ChatTest.php
+++ b/packages/mistral/tests/Unit/Resources/ChatTest.php
@@ -100,13 +100,66 @@ final class ChatTest extends TestCase
         $this->assertInstanceOf(CreateResponse::class, $result);
     }
 
-    public function testCreateWithFormatForNonLargeModel(): void
+    public function testCreateWithFormatForModelWithoutJsonSupport(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $parameters = DataFixtures::CHAT_CREATE_REQUEST;
+        $parameters['model'] = Model::TINY->value;
+        $parameters['response_format'] = ['type' => 'json_object'];
+
+        $this->transport->requestObject(Argument::cetera())->shouldNotBeCalled();
+
+        $chat = $this->createInstance($this->transport->reveal());
+
+        $chat->create($parameters);
+    }
+
+    public function testCreateWithFormatForModelOutsideTheCatalog(): void
+    {
+        $response = DataFixtures::CHAT_CREATE_RESPONSE;
+        $response['model'] = 'zai-glm-5-2';
+
+        $parameters = DataFixtures::CHAT_CREATE_REQUEST;
+        $parameters['model'] = 'zai-glm-5-2';
+        $parameters['response_format'] = ['type' => 'json_object'];
+
+        $response = new ObjectResponse($response, MetaInformation::from([]));
+        $this->transport->requestObject(
+            Argument::that(static fn (Payload $payload) => $parameters === $payload->parameters),
+        )->willReturn($response);
+
+        $chat = $this->createInstance($this->transport->reveal());
+
+        $this->assertSame('zai-glm-5-2', $chat->create($parameters)->model);
+    }
+
+    public function testCreateWithReasoningEffort(): void
+    {
+        $response = DataFixtures::CHAT_CREATE_RESPONSE;
+        $response['model'] = Model::MEDIUM->value;
+
+        $parameters = DataFixtures::CHAT_CREATE_REQUEST;
+        $parameters['model'] = Model::MEDIUM->value;
+        $parameters['reasoning_effort'] = 'none';
+
+        $response = new ObjectResponse($response, MetaInformation::from([]));
+        $this->transport->requestObject(
+            Argument::that(static fn (Payload $payload) => $parameters === $payload->parameters),
+        )->willReturn($response);
+
+        $chat = $this->createInstance($this->transport->reveal());
+
+        $this->assertSame(Model::MEDIUM->value, $chat->create($parameters)->model);
+    }
+
+    public function testCreateWithUnknownReasoningEffort(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $parameters = DataFixtures::CHAT_CREATE_REQUEST;
         $parameters['model'] = Model::MEDIUM->value;
-        $parameters['response_format'] = ['type' => 'json_object'];
+        $parameters['reasoning_effort'] = 'medium';
 
         $this->transport->requestObject(Argument::cetera())->shouldNotBeCalled();
 

--- a/packages/mistral/tests/Unit/Responses/Chat/ContentChunksTest.php
+++ b/packages/mistral/tests/Unit/Responses/Chat/ContentChunksTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Tests\Unit\Responses\Chat;
+
+use ModelflowAi\Mistral\Responses\Chat\ContentChunks;
+use PHPUnit\Framework\TestCase;
+
+final class ContentChunksTest extends TestCase
+{
+    public function testToTextKeepsAString(): void
+    {
+        $this->assertSame('Lorem Ipsum', ContentChunks::toText('Lorem Ipsum'));
+        $this->assertNull(ContentChunks::toText(null));
+    }
+
+    public function testToTextDropsTheThinkingTrace(): void
+    {
+        $content = [
+            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Let me think.']]],
+            ['type' => 'text', 'text' => 'Lorem Ipsum'],
+        ];
+
+        $this->assertSame('Lorem Ipsum', ContentChunks::toText($content));
+    }
+
+    public function testToTextJoinsTheAnswerChunks(): void
+    {
+        $content = [
+            ['type' => 'text', 'text' => 'Lorem '],
+            ['type' => 'text'],
+            'Ipsum',
+        ];
+
+        $this->assertSame('Lorem Ipsum', ContentChunks::toText($content));
+    }
+
+    public function testToTextReturnsAnEmptyStringWhileOnlyThinking(): void
+    {
+        $content = [
+            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Still thinking.']]],
+        ];
+
+        $this->assertSame('', ContentChunks::toText($content));
+    }
+}

--- a/packages/mistral/tests/Unit/Responses/Chat/CreateResponseMessageTest.php
+++ b/packages/mistral/tests/Unit/Responses/Chat/CreateResponseMessageTest.php
@@ -29,4 +29,17 @@ final class CreateResponseMessageTest extends TestCase
         $this->assertSame($messageData['role'], $message->role);
         $this->assertSame($messageData['content'], $message->content);
     }
+
+    public function testFromThinkingModel(): void
+    {
+        $message = CreateResponseMessage::from([
+            'role' => 'assistant',
+            'content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Let me think.']]],
+                ['type' => 'text', 'text' => 'Lorem Ipsum'],
+            ],
+        ]);
+
+        $this->assertSame('Lorem Ipsum', $message->content);
+    }
 }

--- a/packages/mistral/tests/Unit/Responses/Chat/CreateStreamedResponseDeltaTest.php
+++ b/packages/mistral/tests/Unit/Responses/Chat/CreateStreamedResponseDeltaTest.php
@@ -30,6 +30,18 @@ final class CreateStreamedResponseDeltaTest extends TestCase
         $this->assertSame($attributes['content'], $message->content);
     }
 
+    public function testFromThinkingModel(): void
+    {
+        $message = CreateStreamedResponseDelta::from([
+            'content' => [
+                ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'Let me think.']]],
+                ['type' => 'text', 'text' => 'Lorem'],
+            ],
+        ]);
+
+        $this->assertSame('Lorem', $message->content);
+    }
+
     public function testFromWithTools(): void
     {
         $attributes = DataFixtures::CHAT_CREATE_STREAMED_RESPONSES_WITH_TOOLS[0]['choices'][0]['delta'];


### PR DESCRIPTION
Prepares the Mistral side for two things that arrived in August: Mistral Medium 3.5 as a model worth offering, and Mistral hosting third-party models on its own infrastructure, starting with [Z.ai GLM-5.2](https://docs.mistral.ai/models/zai-glm-5-2).

## Models the enum does not list

`MistralChatAdapter::handleRequest()` opened with

```php
if (Model::from($this->model)->jsonSupported()) {
```

so any id outside the enum threw a `ValueError` before the request was built — on every request, not only the ones asking for a response format. The same call sits in `supports()`, `supportsResponseFormat()` and in the client's own parameter validation.

Two reasons that is not tenable any more. Mistral releases models faster than this list follows them, and `zai-glm-5-2` is not a Mistral model at all — it will never sensibly be a case of `ModelflowAi\Mistral\Model`. Unknown ids now go through `Model::jsonSupportedBy()` / `toolsSupportedBy()`, which fall back to the assumption that a model nobody catalogued here is a current one and supports both. Known ids keep their answers.

`Model::MEDIUM` also gains JSON support, which Medium 3.5 has.

## reasoning_effort

Small 4 and Medium 3.5 are [hybrid models](https://docs.mistral.ai/capabilities/reasoning): `reasoning_effort: high` returns a thinking chunk before the answer, `none` leaves it out. Mistral documents quiet as the default, but a default is not a contract and thinking tokens are billed as output — the same reason #158 and #160 pinned this for Anthropic, OpenAI and Google.

So the adapter sends `none` unless an effort is configured:

```php
new MistralChatAdapter($client, 'mistral-medium-latest');                             // reasoning_effort: none
new MistralChatAdapter($client, 'mistral-medium-latest', ReasoningEffortEnum::HIGH);  // reasoning_effort: high
new MistralChatAdapter($client, 'mistral-large-latest');                              // not sent at all
```

The list of models that take the parameter is spelled out one id at a time rather than matched as a family prefix: the snapshots released before a family became hybrid carry the same name, and Mistral answers the parameter with an error on those. A configured effort that a model cannot honour warns and is dropped instead of failing the request, mirroring the OpenAI adapter.

## Verification

`composer test` and `phpstan` green in both `mistral` (56 tests) and `mistral-adapter` (40 tests), `php-cs-fixer` without changes. Rector could not run locally — the packages carry the lowest dependency set, where the constant #159 moved to does not exist yet; the lint job installs the highest set and will tell.

No smoke test against the live API yet: which snapshot `mistral-medium-latest` currently resolves to should be confirmed before anyone relies on it being 3.5.

## Thinking responses are not strings

Found in review: a model asked for `high` answers with a chunk list rather than a string — `thinking` for the trace, `text` for the answer — and streaming switches shape mid-response. Both response DTOs declare `content` as `?string`, so that would have ended in a `TypeError`. `ContentChunks::toText()` folds the list back into the string the responses promise, keeping the answer and dropping the trace.

Replaying the trace in multi-turn conversations, which the docs ask for, needs `AIChatResponseMessage` to model thinking at all — a chat-package change that touches every adapter, so not here.
