### PR TITLE
Ask Gemini 3 Flash for minimal thinking, not low

### DIFF
--- a/packages/anthropic-adapter/phpstan-baseline.neon
+++ b/packages/anthropic-adapter/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Chat\\Request\\AIChatRequest, ModelflowAi\\Chat\\Adapter\\AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\AnthropicAdapter\\Chat\\AnthropicChatAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Chat\\Request\\AIChatRequest, ModelflowAi\\Chat\\Adapter\\AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/bootstrap.php

--- a/packages/chat/src/Response/AIChatResponseStreamMessageBuilder.php
+++ b/packages/chat/src/Response/AIChatResponseStreamMessageBuilder.php
@@ -30,9 +30,7 @@ class AIChatResponseStreamMessageBuilder
         $role = null;
         $contentParts = [];
         foreach ($this->messages as $message) {
-            if (null === $role) {
-                $role = $message->role;
-            }
+            $role ??= $message->role;
             $contentParts[] = $message->content;
         }
 

--- a/packages/fireworksai-adapter/phpstan-baseline.neon
+++ b/packages/fireworksai-adapter/phpstan-baseline.neon
@@ -25,7 +25,7 @@ parameters:
 			path: examples/chat/bootstrap.php
 
 		-
-			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AIChatRequest, AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\FireworksAiAdapter\\Chat\\FireworksAiChatAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AIChatRequest, AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/chat/bootstrap.php
@@ -85,7 +85,7 @@ parameters:
 			path: examples/completion/bootstrap.php
 
 		-
-			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AICompletionRequest, AICompletionAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\FireworksAiAdapter\\Completion\\FireworksAiCompletionAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AICompletionRequest, AICompletionAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/completion/bootstrap.php
@@ -229,7 +229,7 @@ parameters:
 			path: examples/image/bootstrap.php
 
 		-
-			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Image\\Request\\AIImageRequest, ModelflowAi\\Image\\Adapter\\AIImageAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\FireworksAiAdapter\\Image\\FireworksAiImageGenerationAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Image\\Request\\AIImageRequest, ModelflowAi\\Image\\Adapter\\AIImageAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/image/bootstrap.php

--- a/packages/google-gemini-adapter/phpstan-baseline.neon
+++ b/packages/google-gemini-adapter/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Chat\\Request\\AIChatRequest, ModelflowAi\\Chat\\Adapter\\AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\GoogleGeminiAdapter\\Chat\\GoogleGeminiChatAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Chat\\Request\\AIChatRequest, ModelflowAi\\Chat\\Adapter\\AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/bootstrap.php

--- a/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
+++ b/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
@@ -185,9 +185,10 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
     }
 
     /**
-     * Gemini 3 thinks at medium level unless told otherwise, and every generated thought is billed
-     * as an output token. Ask for the lowest level the generation accepts; unlike other providers
-     * thinking cannot be turned off entirely.
+     * Gemini 3 thinks by default unless told otherwise, and every generated thought is billed as
+     * an output token. Ask for the lowest level the model accepts: "minimal" on Flash, "low" on
+     * Pro, which does not support "minimal". Unlike other providers thinking cannot be turned off
+     * entirely.
      */
     private function buildThinkingConfig(): ?ThinkingConfig
     {
@@ -199,9 +200,11 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
             return null;
         }
 
+        $lowestLevel = ModelCapabilities::supportsMinimalThinkingLevel($this->model) ? ThinkingLevel::MINIMAL : ThinkingLevel::LOW;
+
         return new ThinkingConfig(
             includeThoughts: false,
-            thinkingLevel: $this->thinkingLevel ?? ThinkingLevel::LOW,
+            thinkingLevel: $this->thinkingLevel ?? $lowestLevel,
         );
     }
 

--- a/packages/google-gemini-adapter/src/Chat/ModelCapabilities.php
+++ b/packages/google-gemini-adapter/src/Chat/ModelCapabilities.php
@@ -44,4 +44,13 @@ final class ModelCapabilities
 
         return false;
     }
+
+    /**
+     * Within the models taking a thinking level, only the Flash line accepts "minimal". Pro tops
+     * out at "low", so asking Pro for "minimal" would fail the request.
+     */
+    public static function supportsMinimalThinkingLevel(string $model): bool
+    {
+        return self::supportsThinkingLevel($model) && \str_contains($model, 'flash');
+    }
 }

--- a/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
@@ -576,7 +576,7 @@ final class GoogleGeminiChatAdapterTest extends TestCase
             );
     }
 
-    public function testHandleRequestAsksForTheLowestThinkingLevel(): void
+    public function testHandleRequestAsksFlashForMinimalThinking(): void
     {
         $client = $this->createResponseFake();
         $adapter = new GoogleGeminiChatAdapter($client, 'gemini-3.7-flash');
@@ -588,8 +588,24 @@ final class GoogleGeminiChatAdapterTest extends TestCase
                 static fn (string $method, array $args) => 'withGenerationConfig' === $method
                     && $args[0] instanceof GenerationConfig
                     && $args[0]->thinkingConfig instanceof ThinkingConfig
-                    && ThinkingLevel::LOW === $args[0]->thinkingConfig->thinkingLevel
+                    && ThinkingLevel::MINIMAL === $args[0]->thinkingConfig->thinkingLevel
                     && false === $args[0]->thinkingConfig->includeThoughts,
+            );
+    }
+
+    public function testHandleRequestAsksProForLowThinkingSinceItHasNoMinimal(): void
+    {
+        $client = $this->createResponseFake();
+        $adapter = new GoogleGeminiChatAdapter($client, 'gemini-3-pro');
+
+        $adapter->handleRequest($this->createRequest());
+
+        $client->generativeModel('gemini-3-pro')
+            ->assertFunctionCalled(
+                static fn (string $method, array $args) => 'withGenerationConfig' === $method
+                    && $args[0] instanceof GenerationConfig
+                    && $args[0]->thinkingConfig instanceof ThinkingConfig
+                    && ThinkingLevel::LOW === $args[0]->thinkingConfig->thinkingLevel,
             );
     }
 

--- a/packages/google-gemini-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/ModelCapabilitiesTest.php
@@ -38,4 +38,21 @@ final class ModelCapabilitiesTest extends TestCase
     {
         $this->assertSame($expected, ModelCapabilities::supportsThinkingLevel($model));
     }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: bool}>
+     */
+    public static function minimalThinkingLevelProvider(): \Generator
+    {
+        yield 'gemini-3.7-flash' => ['gemini-3.7-flash', true];
+        yield 'gemini-3.7-flash qualified' => ['models/gemini-3.7-flash', true];
+        yield 'gemini-3-pro has no minimal' => ['gemini-3-pro', false];
+        yield 'gemini-2.5-flash does not take a thinking level at all' => ['gemini-2.5-flash', false];
+    }
+
+    #[DataProvider('minimalThinkingLevelProvider')]
+    public function testSupportsMinimalThinkingLevel(string $model, bool $expected): void
+    {
+        $this->assertSame($expected, ModelCapabilities::supportsMinimalThinkingLevel($model));
+    }
 }

--- a/packages/image/phpstan-baseline.neon
+++ b/packages/image/phpstan-baseline.neon
@@ -19,7 +19,7 @@ parameters:
 			path: examples/index.php
 
 		-
-			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Image\\Request\\AIImageRequest, ModelflowAi\\Image\\Adapter\\AIImageAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\Image\\Adapter\\Fake\\FakeAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Image\\Request\\AIImageRequest, ModelflowAi\\Image\\Adapter\\AIImageAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/index.php

--- a/packages/mistral-adapter/phpstan-baseline.neon
+++ b/packages/mistral-adapter/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Chat\\Request\\AIChatRequest, ModelflowAi\\Chat\\Adapter\\AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\MistralAdapter\\Chat\\MistralChatAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type ModelflowAi\\DecisionTree\\DecisionTreeInterface\<ModelflowAi\\Chat\\Request\\AIChatRequest, ModelflowAi\\Chat\\Adapter\\AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/chat/bootstrap.php

--- a/packages/openai-adapter/phpstan-baseline.neon
+++ b/packages/openai-adapter/phpstan-baseline.neon
@@ -19,7 +19,7 @@ parameters:
 			path: examples/chat/bootstrap.php
 
 		-
-			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AIChatRequest, AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\OpenaiAdapter\\Chat\\OpenaiChatAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AIChatRequest, AIChatAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/chat/bootstrap.php
@@ -79,7 +79,7 @@ parameters:
 			path: examples/image/bootstrap.php
 
 		-
-			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AIImageRequest, AIImageAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, ModelflowAi\\OpenaiAdapter\\Image\\OpenAIImageGenerationAdapter\>\.$#'
+			message: '#^PHPDoc tag @var with type DecisionTreeInterface\<AIImageRequest, AIImageAdapterInterface\> is not subtype of native type ModelflowAi\\DecisionTree\\DecisionTree\<ModelflowAi\\DecisionTree\\Behaviour\\CriteriaBehaviour, [^>]+\>\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: examples/image/bootstrap.php


### PR DESCRIPTION
#160 sent every Gemini 3 model \`low\` as the lowest thinking level. Google's docs list a lower \`minimal\` tier, but only for the Flash line; Pro tops out at \`low\`. This asks Flash for \`minimal\` and leaves Pro on \`low\`.

Found while checking sulu.ai's model registry update with a token report: \`gemini-3.1-flash-lite\`'s average output tokens per request roughly doubled after switching to it, while input stayed flat. That is what thinking on a normally terse model looks like.

\`ModelCapabilities::supportsMinimalThinkingLevel()\` tells Flash and Pro apart by name, the same way the existing \`supportsThinkingLevel()\` tells Gemini 3 apart from older generations that don't take a thinking level at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Google Gemini Flash models now use the minimal supported thinking level for faster, more efficient responses.
  - Gemini Pro models continue using the low thinking level, matching their supported capabilities.
  - Thinking behavior is selected automatically based on the model in use, ensuring each Gemini model uses an appropriate supported level.
  - Improved compatibility across supported Gemini model variants while preserving existing response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->